### PR TITLE
Fix TypeScript imports

### DIFF
--- a/src/api-client/base.ts
+++ b/src/api-client/base.ts
@@ -13,7 +13,7 @@
  */
 
 
-import type { Configuration } from './configuration';
+import type { Configuration } from './configuration.js';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios';

--- a/src/api-client/common.ts
+++ b/src/api-client/common.ts
@@ -13,10 +13,10 @@
  */
 
 
-import type { Configuration } from "./configuration";
-import type { RequestArgs } from "./base";
+import type { Configuration } from "./configuration.js";
+import type { RequestArgs } from "./base.js";
 import type { AxiosInstance, AxiosResponse } from 'axios';
-import { RequiredError } from "./base";
+import { RequiredError } from "./base.js";
 
 /**
  *

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -13,6 +13,6 @@
  */
 
 
-export * from "./api";
-export * from "./configuration";
+export * from "./api.js";
+export * from "./configuration.js";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
  import './assets/main.css' // Import global CSS
 import { createApp } from 'vue'
 import App from './App.vue'
-import apiPlugin from './plugins/api'
-import router from './router'
+import apiPlugin from './plugins/api.js'
+import router from './router/index.js'
 import ApiKeyInput from './components/ApiKeyInput.vue'
 
 const app = createApp(App)

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -1,6 +1,6 @@
 import type { App } from 'vue'
-import { BillingApi, CrawlingApi, ExtractionApi, MappingApi, ScrapingApi } from '../api-client'
-import apiConfig from '../config/api'
+import { BillingApi, CrawlingApi, ExtractionApi, MappingApi, ScrapingApi } from '../api-client/index.js'
+import apiConfig from '../config/api.js'
 
 const apiPlugin = {
   install(app: App) {


### PR DESCRIPTION
## Summary
- add `.js` file extensions for NodeNext compatibility in API client and app

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840abe690d4832eb9e43704cbf43ede