### PR TITLE
Fix crawl status fields and implement search

### DIFF
--- a/src/components/SearchView.vue
+++ b/src/components/SearchView.vue
@@ -109,10 +109,15 @@ async function onSearch() {
     searchOptions: {
       limit: options.value.maxResults,
     },
+    // Some deployments expect snake_case option names
+    search_options: {
+      limit: options.value.maxResults,
+    },
   }
 
   if (options.value.extractContent) {
     payload.scrapeOptions = { formats: ['markdown'] }
+    payload.scrape_options = { formats: ['markdown'] }
   }
 
   try {

--- a/src/views/ExtractView.vue
+++ b/src/views/ExtractView.vue
@@ -156,23 +156,23 @@ const submitExtraction = async () => {
     }
 
     // Construct the request payload according to OpenAPI spec
-    const requestPayload: ExtractDataRequest = {
+    const requestPayload: any = {
       urls: urlList,
-      // Only include extractionOptions if prompt or schema is provided
-      ...( (extractionPrompt.value || parsedJsonSchema.value) && {
-          extractionOptions: {
-            ...(extractionPrompt.value && { prompt: extractionPrompt.value }),
-            ...(parsedJsonSchema.value && { schema: parsedJsonSchema.value }),
-            // To enable extra options, uncomment and bind to your form:
-            // enableWebSearch: options.value.enableWebSearch,
-            // showSources: options.value.showSources,
-          }
-        }
-      ),
-      // Add scanOptions or scrapeOptions if needed
-      // scanOptions: { ... },
-      // scrapeOptions: { formats: ['markdown'] } // Example
     };
+
+    // Global prompt/schema according to OpenAPI specification
+    if (extractionPrompt.value) {
+      requestPayload.extractionPrompt = extractionPrompt.value;
+    }
+
+    if (parsedJsonSchema.value) {
+      requestPayload.extractionSchema = parsedJsonSchema.value;
+      // When using a schema, ensure JSON output is requested
+      requestPayload.scrapeOptions = {
+        formats: ['json'],
+      };
+    }
+
 
   try {
     console.log("Extraction Payload:", JSON.stringify(requestPayload, null, 2));


### PR DESCRIPTION
## Summary
- handle `processed` pages in crawl progress
- call correct `extractData` method for extraction API
- implement search view with real API calls

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840b6664c14832e94e135e5ca1cde71