### PR TITLE
Rewrite crawl view with progress

### DIFF
--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -198,8 +198,22 @@ async function downloadFormat(fmt: string) {
   status.value.data.forEach((page, idx) => {
     const data: any = (page as any)[key]
     if (!data) return
+    const meta: any = (page as any).metadata || {}
+    let fileName = `page_${idx + 1}`
+    if (meta.sourceURL) {
+      try {
+        const urlObj = new URL(meta.sourceURL)
+        fileName = `${urlObj.hostname}${urlObj.pathname}`
+      } catch {
+        // ignore malformed URLs
+      }
+    }
+    fileName = fileName
+      .replace(/^\/+/, '')
+      .replace(/\/$/, '')
+      .replace(/[\\/?%*:|"<>]/g, '_') || `page_${idx + 1}`
     const content = typeof data === 'object' ? JSON.stringify(data, null, 2) : String(data)
-    zip.file(`page_${idx + 1}${ext}`, content)
+    zip.file(`${fileName}${ext}`, content)
   })
   const blob = await zip.generateAsync({ type: 'blob' })
   saveAs(blob, `${key}_files_${currentId.value}.zip`)


### PR DESCRIPTION
## Summary
- overhaul `/crawl` page using OpenAPI specs
- implement progress tracking and preview while crawl runs
- add download buttons per file type with zip support
- store crawl history locally for reloading jobs

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68410842c080832e9a77c7c64b0a6463