### PR TITLE
[firecrawl-ui] Add JSDoc for exported components

### DIFF
--- a/src/components/ApiKeyInput.vue
+++ b/src/components/ApiKeyInput.vue
@@ -42,6 +42,12 @@
 <script lang="ts">
 import { defineComponent, ref, onMounted } from "vue";
 
+/**
+ * Component allowing users to configure and store the Firecrawl API key.
+ *
+ * @returns Component options for the API key input view.
+ */
+
 export default defineComponent({
   name: "ApiKeyInput",
   setup() {

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -2,8 +2,14 @@ import type { App } from 'vue'
 import { BillingApi, CrawlingApi, ExtractionApi, MappingApi, ScrapingApi, SearchApi } from '../api-client/index.js'
 import apiConfig from '../config/api.js'
 
+/**
+ * Vue plugin that registers Firecrawl API clients.
+ *
+ * @param app - The Vue application instance.
+ * @returns void
+ */
 const apiPlugin = {
-  install(app: App) {
+  install(app: App): void {
     const apis = {
       billing: new BillingApi(apiConfig),
       crawling: new CrawlingApi(apiConfig),

--- a/src/views/ApiConfigView.vue
+++ b/src/views/ApiConfigView.vue
@@ -16,6 +16,11 @@ import { defineComponent } from "vue";
 import { useRouter } from "vue-router";
 import ApiKeyInput from "@/components/ApiKeyInput.vue";
 
+/**
+ * Component for configuring the API key before using the application.
+ *
+ * @returns Component options for the API configuration view.
+ */
 export default defineComponent({
   name: "ApiConfigView",
   components: {

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -551,6 +551,11 @@ interface FormData {
   webhookOptions: WebhookOptions;
 }
 
+/**
+ * Component allowing users to configure and run crawl jobs.
+ *
+ * @returns Component options for the crawl view.
+ */
 export default defineComponent({
   name: "CrawlView",
   setup() {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -101,6 +101,8 @@ import IconSupport from "@/components/icons/IconSupport.vue";
  * @component
  * @example
  * <HomeView />
+ *
+ * @returns Component options for the home page.
  */
 export default defineComponent({
   name: "HomeView",

--- a/src/views/ScrapeView.vue
+++ b/src/views/ScrapeView.vue
@@ -299,6 +299,11 @@ interface FormDataChangeTrackingOptions {
   frequency: number; // frequency in minutes to check for changes
 }
 
+/**
+ * Component for scraping a single URL with advanced options.
+ *
+ * @returns Component options for the scraping view.
+ */
 export default defineComponent({
   name: "ScrapeView",
   setup() {


### PR DESCRIPTION
## Summary
- document api plugin install function
- add JSDoc blocks for ApiKeyInput component
- document views: ApiConfigView, CrawlView, HomeView, ScrapeView

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68455e6b5f1c832eaba49ff9f680bf02