### PR TITLE
[firecrawl-ui] Improve crawl UI

### DIFF
--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -45,7 +45,7 @@
       <ul>
         <li v-for="(url, index) in urls" :key="index">{{ url }}</li>
       </ul>
-      <button class="primary-button download-button" @click="downloadJson">Download JSON</button>
+      <button class="download-button" @click="downloadJson">Download JSON</button>
     </div>
   </div>
 </template>
@@ -209,5 +209,14 @@ button:hover {
   padding: 0.4rem 0.8rem;
   font-size: 0.9rem;
   margin-top: 0;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
 }
 </style>

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -45,7 +45,7 @@
       <ul>
         <li v-for="(url, index) in urls" :key="index">{{ url }}</li>
       </ul>
-      <button class="primary-button" @click="downloadJson">Download JSON</button>
+      <button class="primary-button download-button" @click="downloadJson">Download JSON</button>
     </div>
   </div>
 </template>
@@ -203,5 +203,11 @@ button:hover {
 
 .status {
   margin-top: 0.5rem;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  margin-top: 0;
 }
 </style>

--- a/src/components/SearchView.vue
+++ b/src/components/SearchView.vue
@@ -59,11 +59,11 @@
       <div class="download-section">
         <h3>Download Results</h3>
         <div v-for="fmt in activeFormats" :key="fmt" class="download-btn">
-          <button class="primary-button" @click="handleDownload(fmt)">
+          <button class="primary-button download-button" @click="handleDownload(fmt)">
             Download {{ fmt }} Archive
           </button>
         </div>
-        <button class="primary-button" @click="handleDownload('Full JSON')">
+        <button class="primary-button download-button" @click="handleDownload('Full JSON')">
           Download Full JSON
         </button>
       </div>
@@ -365,5 +365,11 @@ async function handleDownload(type: string): Promise<void> {
 
 .download-section {
   margin-top: 20px;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  margin-top: 0;
 }
 </style>

--- a/src/components/SearchView.vue
+++ b/src/components/SearchView.vue
@@ -58,14 +58,19 @@
       </ul>
       <div class="download-section">
         <h3>Download Results</h3>
-        <div v-for="fmt in activeFormats" :key="fmt" class="download-btn">
-          <button class="download-button" @click="handleDownload(fmt)">
+        <div class="download-buttons">
+          <button
+            v-for="fmt in activeFormats"
+            :key="fmt"
+            class="download-button"
+            @click="handleDownload(fmt)"
+          >
             Download {{ fmt }} Archive
           </button>
+          <button class="download-button" @click="handleDownload('Full JSON')">
+            Download Full JSON
+          </button>
         </div>
-        <button class="download-button" @click="handleDownload('Full JSON')">
-          Download Full JSON
-        </button>
       </div>
     </section>
   </div>
@@ -365,6 +370,12 @@ async function handleDownload(type: string): Promise<void> {
 
 .download-section {
   margin-top: 20px;
+}
+
+.download-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .download-button {

--- a/src/components/SearchView.vue
+++ b/src/components/SearchView.vue
@@ -59,11 +59,11 @@
       <div class="download-section">
         <h3>Download Results</h3>
         <div v-for="fmt in activeFormats" :key="fmt" class="download-btn">
-          <button class="primary-button download-button" @click="handleDownload(fmt)">
+          <button class="download-button" @click="handleDownload(fmt)">
             Download {{ fmt }} Archive
           </button>
         </div>
-        <button class="primary-button download-button" @click="handleDownload('Full JSON')">
+        <button class="download-button" @click="handleDownload('Full JSON')">
           Download Full JSON
         </button>
       </div>
@@ -371,5 +371,14 @@ async function handleDownload(type: string): Promise<void> {
   padding: 0.4rem 0.8rem;
   font-size: 0.9rem;
   margin-top: 0;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
 }
 </style>

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -341,11 +341,11 @@
     <div v-if="progress === 100 && crawlStatus === 'completed'" class="download-section">
       <h2>Download Results</h2>
       <div v-for="fmt in activeFormats" :key="fmt" class="download-btn">
-        <button class="primary-button" @click="handleDownload(fmt)">
+        <button class="primary-button download-button" @click="handleDownload(fmt)">
           Download {{ fmt }} Archive
         </button>
       </div>
-      <button class="primary-button" @click="handleDownload('Full JSON')">
+      <button class="primary-button download-button" @click="handleDownload('Full JSON')">
         Download Full JSON
       </button>
     </div>
@@ -368,11 +368,11 @@
       <div class="download-section">
         <h3>Download Results</h3>
         <div v-for="fmt in selectedFormats" :key="fmt" class="download-btn">
-          <button class="primary-button" @click="handleDownload(fmt, selectedCrawl.id)">
+          <button class="primary-button download-button" @click="handleDownload(fmt, selectedCrawl.id)">
             Download {{ fmt }} Archive
           </button>
         </div>
-        <button class="primary-button" @click="handleDownload('Full JSON', selectedCrawl.id)">
+        <button class="primary-button download-button" @click="handleDownload('Full JSON', selectedCrawl.id)">
           Download Full JSON
         </button>
       </div>
@@ -1320,6 +1320,12 @@ export default defineComponent({
 }
 
 .history-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  margin-top: 0;
+}
+
+.download-button {
   padding: 0.4rem 0.8rem;
   font-size: 0.9rem;
   margin-top: 0;

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -368,11 +368,17 @@
       <div class="download-section">
         <h3>Download Results</h3>
         <div v-for="fmt in selectedFormats" :key="fmt" class="download-btn">
-          <button class="primary-button download-button" @click="handleDownload(fmt, selectedCrawl.id)">
+          <button
+            class="primary-button download-button"
+            @click="handleDownload(fmt, selectedCrawl.id)"
+          >
             Download {{ fmt }} Archive
           </button>
         </div>
-        <button class="primary-button download-button" @click="handleDownload('Full JSON', selectedCrawl.id)">
+        <button
+          class="primary-button download-button"
+          @click="handleDownload('Full JSON', selectedCrawl.id)"
+        >
           Download Full JSON
         </button>
       </div>
@@ -383,7 +389,6 @@
     <!-- Section for crawl history -->
     <div class="crawl-history-section">
       <h2>Crawl History</h2>
-      <button class="primary-button" type="button" @click="clearHistory">Clear History</button>
       <div v-if="crawlHistory.length > 0">
         <ul class="history-list">
           <li
@@ -403,6 +408,9 @@
       </div>
       <div v-else>
         <p>No crawl history available.</p>
+      </div>
+      <div class="clear-history-wrapper">
+        <button class="primary-button" type="button" @click="clearHistory">Clear History</button>
       </div>
     </div>
   </div>
@@ -1320,15 +1328,29 @@ export default defineComponent({
 }
 
 .history-button {
-  padding: 0.4rem 0.8rem;
-  font-size: 0.9rem;
-  margin-top: 0;
+  margin-left: 10px;
+  padding: 5px 10px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.history-button:hover {
+  background-color: #0056b3;
 }
 
 .download-button {
   padding: 0.4rem 0.8rem;
   font-size: 0.9rem;
   margin-top: 0;
+}
+
+.clear-history-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
 }
 
 .selected-crawl {

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -340,14 +340,19 @@
     <!-- Section for download options after crawl completion -->
     <div v-if="progress === 100 && crawlStatus === 'completed'" class="download-section">
       <h2>Download Results</h2>
-      <div v-for="fmt in activeFormats" :key="fmt" class="download-btn">
-        <button class="download-button" @click="handleDownload(fmt)">
+      <div class="download-buttons">
+        <button
+          v-for="fmt in activeFormats"
+          :key="fmt"
+          class="download-button"
+          @click="handleDownload(fmt)"
+        >
           Download {{ fmt }} Archive
         </button>
+        <button class="download-button" @click="handleDownload('Full JSON')">
+          Download Full JSON
+        </button>
       </div>
-      <button class="download-button" @click="handleDownload('Full JSON')">
-        Download Full JSON
-      </button>
     </div>
 
     <!-- Section for selected crawl details -->
@@ -367,14 +372,19 @@
 
       <div class="download-section">
         <h3>Download Results</h3>
-        <div v-for="fmt in selectedFormats" :key="fmt" class="download-btn">
-          <button class="download-button" @click="handleDownload(fmt, selectedCrawl.id)">
+        <div class="download-buttons">
+          <button
+            v-for="fmt in selectedFormats"
+            :key="fmt"
+            class="download-button"
+            @click="handleDownload(fmt, selectedCrawl.id)"
+          >
             Download {{ fmt }} Archive
           </button>
+          <button class="download-button" @click="handleDownload('Full JSON', selectedCrawl.id)">
+            Download Full JSON
+          </button>
         </div>
-        <button class="download-button" @click="handleDownload('Full JSON', selectedCrawl.id)">
-          Download Full JSON
-        </button>
       </div>
 
       <button class="primary-button" @click="selectedCrawlId = null">Hide Details</button>
@@ -1302,6 +1312,12 @@ export default defineComponent({
 
 .download-section {
   margin-top: 20px;
+}
+
+.download-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .crawl-history-section li {

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -334,6 +334,7 @@
         <div class="progress-bar" :style="{ width: progress + '%' }"></div>
       </div>
       <p>{{ progress }}% Completed</p>
+      <p>{{ pagesCompleted }} / {{ totalPages }} pages processed</p>
     </div>
 
     <!-- Section for download options after crawl completion -->
@@ -384,17 +385,18 @@
       <h2>Crawl History</h2>
       <button class="primary-button" type="button" @click="clearHistory">Clear History</button>
       <div v-if="crawlHistory.length > 0">
-        <ul>
+        <ul class="history-list">
           <li
             v-for="crawl in crawlHistory"
             :key="crawl.id"
-            :class="{ 'selected-crawl': selectedCrawlId === crawl.id }"
+            :class="['history-item', { 'selected-crawl': selectedCrawlId === crawl.id }]"
           >
-            <strong>{{ crawl.url }}</strong>
-            – {{ new Date(crawl.createdAt).toLocaleString() }} – Status:
-            {{ crawl.status }}
-            <button class="primary-button" type="button" @click.prevent="selectCrawl(crawl.id)">
-              View Details
+            <span class="history-info">
+              <strong>{{ crawl.url }}</strong>
+              – {{ new Date(crawl.createdAt).toLocaleString() }} – Status: {{ crawl.status }}
+            </span>
+            <button class="history-button" type="button" @click.prevent="selectCrawl(crawl.id)">
+              View
             </button>
           </li>
         </ul>
@@ -675,6 +677,10 @@ export default defineComponent({
     const loading = ref(false);
     const crawling = ref(false);
     const progress = ref(0);
+    // Number of pages processed so far
+    const pagesCompleted = ref(0);
+    // Total number of pages in the crawl job
+    const totalPages = ref(0);
     const crawlStatus = ref<string | undefined>('');
     const error = ref('');
     const result = ref<any>(null);
@@ -1028,6 +1034,8 @@ export default defineComponent({
         loading.value = true;
         crawling.value = true;
         progress.value = 0;
+        pagesCompleted.value = 0;
+        totalPages.value = 0;
         error.value = '';
         result.value = null;
 
@@ -1093,6 +1101,8 @@ export default defineComponent({
 
           // Update reactive variables with real data
           crawlStatus.value = data.status;
+          pagesCompleted.value = data.completed || 0;
+          totalPages.value = data.total || 0;
           // Calculate progress based on completed vs total pages
           if (
             data.total !== undefined &&
@@ -1175,6 +1185,8 @@ export default defineComponent({
       loading,
       crawling,
       progress,
+      pagesCompleted,
+      totalPages,
       crawlStatus,
       error,
       result,
@@ -1293,6 +1305,24 @@ export default defineComponent({
 .crawl-history-section li {
   cursor: pointer;
   margin-bottom: 8px;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+}
+
+.history-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.history-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  margin-top: 0;
 }
 
 .selected-crawl {

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -341,11 +341,11 @@
     <div v-if="progress === 100 && crawlStatus === 'completed'" class="download-section">
       <h2>Download Results</h2>
       <div v-for="fmt in activeFormats" :key="fmt" class="download-btn">
-        <button class="primary-button download-button" @click="handleDownload(fmt)">
+        <button class="download-button" @click="handleDownload(fmt)">
           Download {{ fmt }} Archive
         </button>
       </div>
-      <button class="primary-button download-button" @click="handleDownload('Full JSON')">
+      <button class="download-button" @click="handleDownload('Full JSON')">
         Download Full JSON
       </button>
     </div>
@@ -368,17 +368,11 @@
       <div class="download-section">
         <h3>Download Results</h3>
         <div v-for="fmt in selectedFormats" :key="fmt" class="download-btn">
-          <button
-            class="primary-button download-button"
-            @click="handleDownload(fmt, selectedCrawl.id)"
-          >
+          <button class="download-button" @click="handleDownload(fmt, selectedCrawl.id)">
             Download {{ fmt }} Archive
           </button>
         </div>
-        <button
-          class="primary-button download-button"
-          @click="handleDownload('Full JSON', selectedCrawl.id)"
-        >
+        <button class="download-button" @click="handleDownload('Full JSON', selectedCrawl.id)">
           Download Full JSON
         </button>
       </div>
@@ -1345,6 +1339,15 @@ export default defineComponent({
   padding: 0.4rem 0.8rem;
   font-size: 0.9rem;
   margin-top: 0;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
 }
 
 .clear-history-wrapper {
@@ -1354,7 +1357,7 @@ export default defineComponent({
 }
 
 .selected-crawl {
-  background-color: #eef6ff;
+  background-color: #1f2d3d;
 }
 
 .collapsible-header {


### PR DESCRIPTION
## Summary
- show processed/total page count during crawl
- align crawl history items with smaller buttons

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684672aa5204832ebdccfd0e462351fb