### PR TITLE
[firecrawl-ui] Translate French UI text

### DIFF
--- a/src/components/ApiKeyInput.vue
+++ b/src/components/ApiKeyInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="api-key-input">
-    <h2>Configuration de l'API</h2>
+    <h2>API Configuration</h2>
     <form @submit.prevent="saveApiConfig">
       <div class="form-group">
         <label for="apiKey">Firecrawl API Key:</label>
@@ -17,7 +17,7 @@
         </small>
       </div>
       <div class="form-group">
-        <label for="baseUrl">URL de base de l'API Firecrawl (optionnel):</label>
+        <label for="baseUrl">Firecrawl API base URL (optional):</label>
         <input
           id="baseUrl"
           v-model="baseUrl"
@@ -26,7 +26,7 @@
         />
         <small> Leave blank to use the default URL. </small>
       </div>
-      <button type="submit" class="primary-button">Enregistrer</button>
+      <button type="submit" class="primary-button">Save</button>
     </form>
     <div v-if="error" class="error-message">
       {{ error }}
@@ -78,7 +78,7 @@ export default defineComponent({
         // Optional: Reload the page or reconfigure the API instance for immediate effect
         window.location.reload();
       } catch (err) {
-        error.value = err instanceof Error ? err.message : 'Erreur inconnue';
+        error.value = err instanceof Error ? err.message : 'Unknown error';
         success.value = false;
       }
     };

--- a/src/views/ApiConfigView.vue
+++ b/src/views/ApiConfigView.vue
@@ -4,7 +4,7 @@
     <p>A valid API key is required to use Firecrawl.</p>
     <ApiKeyInput />
     <div class="actions">
-      <button @click="handleContinue" class="primary">Continuer vers l'application</button>
+      <button @click="handleContinue" class="primary">Continue to application</button>
     </div>
   </div>
 </template>

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -1091,7 +1091,7 @@ export default defineComponent({
       }
     };
 
-    // ID d'intervalle pour le polling du statut du crawl
+    // Interval ID for polling crawl status
     let intervalId: any = null;
 
     /**


### PR DESCRIPTION
## Summary
- translate French button text to English
- update labels and messages in `ApiKeyInput` to English
- convert a French comment in `CrawlView` to English

## Testing
- `npm ci`
- `npx prettier --check .`
- `npx eslint .`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68472b42c400832e889bba3ee413a241