### PR TITLE
[firecrawl-ui] Add custom 404 redirect and nginx config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: npm test --if-present
       - name: Build
         run: npm run build
+      - name: Copy 404 page
+        run: cp public/404.html dist/404.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:stable-alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Preview the built app locally:
 npm run preview
 ```
 
+The `public/404.html` file is copied into the build output and allows GitHub Pages
+to redirect unknown paths to `index.html` for proper client-side routing.
+
 ## Docker
 
 Build the Docker image:
@@ -104,6 +107,9 @@ Run the container and expose the Nginx server:
 ```sh
 docker run -p 8080:8080 firecrawl-ui
 ```
+
+The container includes a custom `nginx.conf` which uses `try_files $uri $uri/ /index.html;`
+to route unknown paths to the application entry point.
 
 A prebuilt image is also published and can be pulled from:
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+  listen 8080;
+  server_name localhost;
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/index.html" />
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="/index.html">/index.html</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `public/404.html` for GitHub Pages
- copy 404 page during workflow build
- introduce `nginx.conf` for SPA routing
- copy config in `Dockerfile`
- document deployment notes in README

## Testing
- `npm ci`
- `npx prettier --check .`
- `npx eslint .`
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_68472b432dbc832ea83d46f33f8003ab