### PR TITLE
[firecrawl-ui] Dynamic API configuration without reload

### DIFF
--- a/src/components/ApiKeyInput.vue
+++ b/src/components/ApiKeyInput.vue
@@ -37,6 +37,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, onMounted } from 'vue';
+import { refreshApiClients } from '@/plugins/api';
 
 /**
  * Component allowing users to configure and store the Firecrawl API key and base URL.
@@ -74,8 +75,8 @@ export default defineComponent({
         error.value = '';
         setTimeout(() => (success.value = false), 3000);
 
-        // Optional: Reload the page or reconfigure the API instance for immediate effect
-        window.location.reload();
+        // Update API clients dynamically without reloading the page
+        refreshApiClients(baseUrl.value, apiKey.value);
       } catch (err) {
         error.value = err instanceof Error ? err.message : 'Unknown error';
         success.value = false;

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,10 +1,12 @@
 import { Configuration } from '../api-client/configuration.js';
 
 /**
- * Returns the base URL for the Firecrawl API
- * @returns {string} The base URL from local storage, environment variables, or default
+ * Returns the base URL for the Firecrawl API.
+ *
+ * @returns {string} The base URL from local storage, environment variables or a
+ *   default value.
  */
-const getBaseUrl = () => {
+const getBaseUrl = (): string => {
   return (
     localStorage.getItem('firecrawl_base_url') ||
     import.meta.env.VITE_FIRECRAWL_API_BASE_URL ||
@@ -16,8 +18,7 @@ const getBaseUrl = () => {
  * Returns the API key for the Firecrawl API
  * @returns {string} The API key from local storage, environment variables, or empty string
  */
-const getApiKey = () => {
-  // Retrieves the API key from local storage or environment variables
+const getApiKey = (): string => {
   return localStorage.getItem('firecrawl_api_key') || import.meta.env.VITE_FIRECRAWL_API_KEY || '';
 };
 
@@ -45,6 +46,40 @@ if (apiKey) {
       Authorization: `Bearer ${apiKey}`,
     },
   };
+}
+
+/**
+ * Updates the API configuration at runtime.
+ *
+ * @param baseUrl - Optional new base URL for the API.
+ * @param apiKeyValue - Optional new API key.
+ */
+export function updateApiConfig(baseUrl?: string, apiKeyValue?: string): void {
+  if (typeof baseUrl === 'string') {
+    localStorage.setItem('firecrawl_base_url', baseUrl);
+    apiConfig.basePath = baseUrl || 'https://api.firecrawl.dev/v1';
+  }
+  if (typeof apiKeyValue === 'string') {
+    localStorage.setItem('firecrawl_api_key', apiKeyValue);
+    apiConfig.apiKey = apiKeyValue;
+  }
+
+  const key = apiKeyValue ?? getApiKey();
+  apiConfig.baseOptions = {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(key ? { Authorization: `Bearer ${key}` } : {}),
+    },
+  };
+}
+
+/**
+ * Retrieve the current API configuration instance.
+ *
+ * @returns The active API configuration.
+ */
+export function getApiConfig(): Configuration {
+  return apiConfig;
 }
 
 export default apiConfig;


### PR DESCRIPTION
## Summary
- update `api.ts` to allow runtime API url/key updates
- refresh API clients when config changes
- update key save logic to refresh API clients instead of reloading

## Testing
- `npm ci`
- `npx prettier --check .`
- `npx eslint .`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68522a234294832e83a37ec1e5364359