### PR TITLE
[firecrawl-ui] Switch to hash-based routing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+openapi.yaml

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router';
+import { createRouter, createWebHashHistory } from 'vue-router';
 import HomeView from '../views/HomeView.vue';
 import ScrapeView from '../views/ScrapeView.vue';
 import CrawlView from '../views/CrawlView.vue';
@@ -9,7 +9,7 @@ import SearchView from '../components/SearchView.vue';
 import AboutView from '../views/AboutView.vue';
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',


### PR DESCRIPTION
## Summary
- use hash history in router
- ignore openapi spec from Prettier formatting

## Testing
- `npm ci`
- `npx prettier --check .`
- `npx eslint .`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6884288c06a4832e937437bc672f87b0