### PR TITLE
[firecrawl-ui] Add spinner and toast notifications

### DIFF
--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="spinner"></div>
+</template>
+
+<script setup lang="ts">
+/**
+ * LoadingSpinner Component
+ *
+ * Displays an animated spinner to indicate a loading state.
+ */
+</script>
+
+<style scoped>
+.spinner {
+  border: 4px solid rgba(0, 0, 0, 0.1);
+  border-left-color: #0066cc;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -1,0 +1,55 @@
+<template>
+  <div :class="['toast', type]" role="alert">
+    {{ message }}
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+
+/**
+ * Toast Component
+ *
+ * Displays a temporary notification message.
+ *
+ * @param message - Text to display in the toast.
+ * @param type - Either 'success' or 'error', determines styling.
+ * @param duration - Duration in milliseconds before the toast dismisses itself.
+ * Emits a `dismiss` event when the toast should be removed.
+ */
+interface Props {
+  message: string;
+  type: 'success' | 'error';
+  duration?: number;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{ (e: 'dismiss'): void }>();
+
+onMounted(() => {
+  setTimeout(() => {
+    emit('dismiss');
+  }, props.duration ?? 3000);
+});
+</script>
+
+<style scoped>
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+
+.toast.success {
+  background-color: #28a745;
+}
+
+.toast.error {
+  background-color: #dc3545;
+}
+</style>


### PR DESCRIPTION
## Summary
- replace static loading text with reusable spinner component
- disable submission buttons during active requests
- add toast notifications for success and error states

## Testing
- `npx prettier --check .`
- `npm ci`
- `npx eslint .`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68a3715040bc832e91290d76ee1becfc