### PR TITLE
style: fix Prettier formatting in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,6 @@
   All code, comments, docstrings, variable and function names must be in English.
 - **Documentation:**
   Every class, function/method, and file should be fully documented (docstrings/JSDoc), including:
-
   - Arguments (type + description)
   - Return values
   - Exceptions (if any)


### PR DESCRIPTION
## Contexte

La CI (`node` job) échoue sur `main` **et donc sur toutes les PR ouvertes** (dont #82) à l'étape **Prettier check** : `AGENTS.md` contient une ligne vide superflue que Prettier refuse.

```
[warn] AGENTS.md
[warn] Code style issues found in the above file.
```

## Correctif

Suppression de la ligne vide (sortie de `prettier --write AGENTS.md`). Après ce changement :

- `npx prettier --check .` → OK
- `npx eslint .` → OK
- `npm run build` → OK

Une fois mergée, il suffit de rebaser #82 (`@dependabot rebase`) pour qu'elle repasse au vert.