### PR TITLE
[firecrawl-ui] Complete Firecrawl v2 API coverage (deep research, llms.txt, billing, batch/crawl/extract controls)

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,6 +6,7 @@ import ApiConfigView from '../views/ApiConfigView.vue';
 import ExtractView from '../views/ExtractView.vue'; // Import the new view
 import MapView from '../components/MapView.vue';
 import SearchView from '../components/SearchView.vue';
+import BillingView from '../views/BillingView.vue';
 import AboutView from '../views/AboutView.vue';
 
 const router = createRouter({
@@ -45,6 +46,11 @@ const router = createRouter({
       path: '/search',
       name: 'search',
       component: SearchView, // Route for the search functionality view.
+    },
+    {
+      path: '/billing',
+      name: 'billing',
+      component: BillingView, // Route for the billing and credit usage view.
     },
     {
       path: '/about',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,8 @@ import ApiConfigView from '../views/ApiConfigView.vue';
 import ExtractView from '../views/ExtractView.vue'; // Import the new view
 import MapView from '../components/MapView.vue';
 import SearchView from '../components/SearchView.vue';
+import ResearchView from '../views/ResearchView.vue';
+import LlmsTxtView from '../views/LlmsTxtView.vue';
 import BillingView from '../views/BillingView.vue';
 import AboutView from '../views/AboutView.vue';
 
@@ -52,6 +54,16 @@ const router = createRouter({
       path: '/search',
       name: 'search',
       component: SearchView, // Route for the search functionality view.
+    },
+    {
+      path: '/research',
+      name: 'research',
+      component: ResearchView, // Route for the deep research functionality.
+    },
+    {
+      path: '/llmstxt',
+      name: 'llmstxt',
+      component: LlmsTxtView, // Route for the LLMs.txt generation view.
     },
     {
       path: '/billing',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router';
 import HomeView from '../views/HomeView.vue';
 import ScrapeView from '../views/ScrapeView.vue';
+import BatchScrapeView from '../views/BatchScrapeView.vue';
 import CrawlView from '../views/CrawlView.vue';
 import ApiConfigView from '../views/ApiConfigView.vue';
 import ExtractView from '../views/ExtractView.vue'; // Import the new view
@@ -21,6 +22,11 @@ const router = createRouter({
       path: '/scrape',
       name: 'scrape',
       component: ScrapeView, // Route for the web scraping functionality.
+    },
+    {
+      path: '/batch-scrape',
+      name: 'batch-scrape',
+      component: BatchScrapeView, // Route for the batch scraping functionality.
     },
     {
       path: '/crawl',

--- a/src/services/firecrawl.ts
+++ b/src/services/firecrawl.ts
@@ -154,9 +154,30 @@ export interface FirecrawlSearchApi {
 }
 
 /**
+ * Team credit usage information returned by Firecrawl.
+ *
+ * Only `remainingCredits` is guaranteed by the API contract; the optional
+ * fields are surfaced when the Firecrawl plan exposes them.
+ */
+export interface CreditUsage {
+  remainingCredits: number | null;
+  planCredits?: number | null;
+  billingPeriodStart?: string | null;
+  billingPeriodEnd?: string | null;
+}
+
+/**
+ * Legacy-compatible billing client.
+ */
+export interface FirecrawlBillingApi {
+  getCreditUsage(): Promise<WrappedResponse<CreditUsage>>;
+}
+
+/**
  * Collection of all Firecrawl adapters exposed to Vue.
  */
 export interface FirecrawlApiClients {
+  billing: FirecrawlBillingApi;
   crawling: FirecrawlCrawlingApi;
   extraction: FirecrawlExtractionApi;
   mapping: FirecrawlMappingApi;
@@ -514,6 +535,35 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
   const http = createHttpClient(apiKey, baseUrl);
 
   return {
+    billing: {
+      async getCreditUsage() {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            data?: {
+              remaining_credits?: number;
+              plan_credits?: number;
+              billing_period_start?: string | null;
+              billing_period_end?: string | null;
+            };
+          }>('/v2/team/credit-usage');
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              remainingCredits:
+                typeof data.remaining_credits === 'number' ? data.remaining_credits : null,
+              planCredits: typeof data.plan_credits === 'number' ? data.plan_credits : null,
+              billingPeriodStart: data.billing_period_start ?? null,
+              billingPeriodEnd: data.billing_period_end ?? null,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch credit usage');
+        }
+      },
+    },
     scraping: {
       async scrapeAndExtractFromUrl(payload) {
         try {

--- a/src/services/firecrawl.ts
+++ b/src/services/firecrawl.ts
@@ -124,12 +124,51 @@ export interface FirecrawlScrapingApi {
 /**
  * Legacy-compatible crawling client.
  */
+export interface CrawlError {
+  id?: string;
+  timestamp?: string | null;
+  url?: string;
+  error?: string;
+}
+
+/**
+ * Crawl error report returned by the errors endpoint.
+ */
+export interface CrawlErrorsReport {
+  errors: CrawlError[];
+  robotsBlocked: string[];
+}
+
 export interface FirecrawlCrawlingApi {
   crawlUrls(
     payload: Record<string, unknown>,
   ): Promise<WrappedResponse<{ id: string; url: string }>>;
   getCrawlStatus(id: string): Promise<WrappedResponse<LegacyCrawlStatusResponse>>;
   cancelCrawl(id: string): Promise<WrappedResponse<{ status: string }>>;
+  getCrawlErrors(id: string): Promise<WrappedResponse<CrawlErrorsReport>>;
+}
+
+/**
+ * Status of a batch scrape job, mirroring the crawl status structure with the
+ * extra `creditsUsed` counter exposed by the batch endpoint.
+ */
+export interface BatchScrapeStatusResponse {
+  status: CrawlJob['status'];
+  completed: number;
+  total: number;
+  creditsUsed: number;
+  next: string | null;
+  data: Record<string, unknown>[];
+}
+
+/**
+ * Legacy-compatible batch scraping client.
+ */
+export interface FirecrawlBatchScrapingApi {
+  batchScrape(
+    payload: Record<string, unknown>,
+  ): Promise<WrappedResponse<{ id: string; url: string }>>;
+  getBatchScrapeStatus(id: string): Promise<WrappedResponse<BatchScrapeStatusResponse>>;
 }
 
 /**
@@ -167,10 +206,18 @@ export interface CreditUsage {
 }
 
 /**
+ * Team token usage information returned by Firecrawl (Extract feature).
+ */
+export interface TokenUsage {
+  remainingTokens: number | null;
+}
+
+/**
  * Legacy-compatible billing client.
  */
 export interface FirecrawlBillingApi {
   getCreditUsage(): Promise<WrappedResponse<CreditUsage>>;
+  getTokenUsage(): Promise<WrappedResponse<TokenUsage>>;
 }
 
 /**
@@ -178,6 +225,7 @@ export interface FirecrawlBillingApi {
  */
 export interface FirecrawlApiClients {
   billing: FirecrawlBillingApi;
+  batchScraping: FirecrawlBatchScrapingApi;
   crawling: FirecrawlCrawlingApi;
   extraction: FirecrawlExtractionApi;
   mapping: FirecrawlMappingApi;
@@ -563,6 +611,25 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
           throw formatApiError(error, 'Failed to fetch credit usage');
         }
       },
+      async getTokenUsage() {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            data?: { remaining_tokens?: number };
+          }>('/v2/team/token-usage');
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              remainingTokens:
+                typeof data.remaining_tokens === 'number' ? data.remaining_tokens : null,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch token usage');
+        }
+      },
     },
     scraping: {
       async scrapeAndExtractFromUrl(payload) {
@@ -637,12 +704,82 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
           );
 
           return {
-            data: {
-              status: response.data.status ?? 'cancelled',
-            },
+            data: { status: response.data.status ?? 'cancelled' },
           };
         } catch (error) {
           throw formatApiError(error, 'Failed to cancel crawl');
+        }
+      },
+      async getCrawlErrors(id) {
+        try {
+          const response = await http.get<{
+            errors?: CrawlError[];
+            robotsBlocked?: string[];
+          }>(`/v2/crawl/${id}/errors`);
+
+          return {
+            data: {
+              errors: response.data.errors ?? [],
+              robotsBlocked: response.data.robotsBlocked ?? [],
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch crawl errors');
+        }
+      },
+    },
+    batchScraping: {
+      async batchScrape(payload) {
+        try {
+          const urls = Array.isArray(payload.urls)
+            ? (payload.urls as unknown[]).filter((url): url is string => typeof url === 'string')
+            : [];
+          // Reuse the single-scrape option mapping to keep batch options in sync.
+          const { options } = toScrapeRequest({ url: '', ...payload });
+          const response = await http.post<{ success: boolean; id: string; url: string }>(
+            '/v2/batch/scrape',
+            {
+              urls,
+              ...options,
+              ...(typeof payload.webhook === 'object' && payload.webhook !== null
+                ? { webhook: payload.webhook }
+                : {}),
+            },
+          );
+
+          return {
+            data: {
+              id: response.data.id,
+              url: response.data.url,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Batch scrape request failed');
+        }
+      },
+      async getBatchScrapeStatus(id) {
+        try {
+          const response = await http.get<{
+            status?: CrawlJob['status'];
+            completed?: number;
+            total?: number;
+            creditsUsed?: number;
+            next?: string | null;
+            data?: Document[];
+          }>(`/v2/batch/scrape/${id}`);
+
+          return {
+            data: {
+              status: response.data.status ?? 'scraping',
+              completed: response.data.completed ?? 0,
+              total: response.data.total ?? 0,
+              creditsUsed: response.data.creditsUsed ?? 0,
+              next: response.data.next ?? null,
+              data: (response.data.data ?? []).map(toLegacyDocument),
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch batch scrape status');
         }
       },
     },

--- a/src/services/firecrawl.ts
+++ b/src/services/firecrawl.ts
@@ -139,6 +139,13 @@ export interface CrawlErrorsReport {
   robotsBlocked: string[];
 }
 
+export interface ActiveCrawl {
+  id: string;
+  url?: string;
+  teamId?: string;
+  options?: Record<string, unknown>;
+}
+
 export interface FirecrawlCrawlingApi {
   crawlUrls(
     payload: Record<string, unknown>,
@@ -146,6 +153,7 @@ export interface FirecrawlCrawlingApi {
   getCrawlStatus(id: string): Promise<WrappedResponse<LegacyCrawlStatusResponse>>;
   cancelCrawl(id: string): Promise<WrappedResponse<{ status: string }>>;
   getCrawlErrors(id: string): Promise<WrappedResponse<CrawlErrorsReport>>;
+  getActiveCrawls(): Promise<WrappedResponse<{ crawls: ActiveCrawl[] }>>;
 }
 
 /**
@@ -169,6 +177,8 @@ export interface FirecrawlBatchScrapingApi {
     payload: Record<string, unknown>,
   ): Promise<WrappedResponse<{ id: string; url: string }>>;
   getBatchScrapeStatus(id: string): Promise<WrappedResponse<BatchScrapeStatusResponse>>;
+  cancelBatchScrape(id: string): Promise<WrappedResponse<{ message: string }>>;
+  getBatchScrapeErrors(id: string): Promise<WrappedResponse<CrawlErrorsReport>>;
 }
 
 /**
@@ -176,6 +186,7 @@ export interface FirecrawlBatchScrapingApi {
  */
 export interface FirecrawlExtractionApi {
   extractData(payload: Record<string, unknown>): Promise<WrappedResponse<FirecrawlExtractResponse>>;
+  getExtractStatus(id: string): Promise<WrappedResponse<FirecrawlExtractResponse>>;
 }
 
 /**
@@ -221,6 +232,67 @@ export interface FirecrawlBillingApi {
 }
 
 /**
+ * A single activity entry emitted while a deep research job progresses.
+ */
+export interface ResearchActivity {
+  type?: string;
+  status?: string;
+  message?: string;
+  timestamp?: string;
+  depth?: number;
+}
+
+/**
+ * A source discovered and analyzed during a deep research job.
+ */
+export interface ResearchSource {
+  url?: string;
+  title?: string;
+  description?: string;
+  favicon?: string;
+}
+
+/**
+ * Status and results of a deep research job.
+ */
+export interface DeepResearchStatus {
+  status: 'processing' | 'completed' | 'failed';
+  finalAnalysis: string;
+  json: Record<string, unknown> | null;
+  activities: ResearchActivity[];
+  sources: ResearchSource[];
+  currentDepth: number;
+  maxDepth: number;
+  totalUrls: number;
+  error: string | null;
+}
+
+/**
+ * Legacy-compatible deep research client.
+ */
+export interface FirecrawlResearchApi {
+  startDeepResearch(payload: Record<string, unknown>): Promise<WrappedResponse<{ id: string }>>;
+  getDeepResearchStatus(id: string): Promise<WrappedResponse<DeepResearchStatus>>;
+}
+
+/**
+ * Status and results of an LLMs.txt generation job.
+ */
+export interface LlmsTxtStatus {
+  status: 'processing' | 'completed' | 'failed';
+  llmstxt: string;
+  llmsfulltxt: string;
+}
+
+/**
+ * Legacy-compatible LLMs.txt generation client.
+ */
+export interface FirecrawlLlmsTxtApi {
+  generateLlmsTxt(payload: Record<string, unknown>): Promise<WrappedResponse<{ id: string }>>;
+  getLlmsTxtStatus(id: string): Promise<WrappedResponse<LlmsTxtStatus>>;
+}
+
+/**
  * Collection of all Firecrawl adapters exposed to Vue.
  */
 export interface FirecrawlApiClients {
@@ -228,7 +300,9 @@ export interface FirecrawlApiClients {
   batchScraping: FirecrawlBatchScrapingApi;
   crawling: FirecrawlCrawlingApi;
   extraction: FirecrawlExtractionApi;
+  llmsTxt: FirecrawlLlmsTxtApi;
   mapping: FirecrawlMappingApi;
+  research: FirecrawlResearchApi;
   scraping: FirecrawlScrapingApi;
   search: FirecrawlSearchApi;
 }
@@ -727,6 +801,19 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
           throw formatApiError(error, 'Failed to fetch crawl errors');
         }
       },
+      async getActiveCrawls() {
+        try {
+          const response = await http.get<{ success?: boolean; crawls?: ActiveCrawl[] }>(
+            '/v2/crawl/active',
+          );
+
+          return {
+            data: { crawls: response.data.crawls ?? [] },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch active crawls');
+        }
+      },
     },
     batchScraping: {
       async batchScrape(payload) {
@@ -782,6 +869,36 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
           throw formatApiError(error, 'Failed to fetch batch scrape status');
         }
       },
+      async cancelBatchScrape(id) {
+        try {
+          const response = await http.delete<{ success?: boolean; message?: string }>(
+            `/v2/batch/scrape/${id}`,
+          );
+
+          return {
+            data: { message: response.data.message ?? 'Batch scrape job cancelled.' },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to cancel batch scrape');
+        }
+      },
+      async getBatchScrapeErrors(id) {
+        try {
+          const response = await http.get<{
+            errors?: CrawlError[];
+            robotsBlocked?: string[];
+          }>(`/v2/batch/scrape/${id}/errors`);
+
+          return {
+            data: {
+              errors: response.data.errors ?? [],
+              robotsBlocked: response.data.robotsBlocked ?? [],
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch batch scrape errors');
+        }
+      },
     },
     extraction: {
       async extractData(payload) {
@@ -794,6 +911,106 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
           };
         } catch (error) {
           throw formatApiError(error, 'Extract request failed');
+        }
+      },
+      async getExtractStatus(id) {
+        try {
+          const response = await http.get<FirecrawlExtractResponse>(`/v2/extract/${id}`);
+
+          return {
+            data: response.data,
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch extract status');
+        }
+      },
+    },
+    research: {
+      async startDeepResearch(payload) {
+        try {
+          const response = await http.post<{ success: boolean; id: string }>(
+            '/v2/deep-research',
+            payload,
+          );
+
+          return {
+            data: { id: response.data.id },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to start deep research');
+        }
+      },
+      async getDeepResearchStatus(id) {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            data?: {
+              status?: DeepResearchStatus['status'];
+              finalAnalysis?: string;
+              json?: Record<string, unknown> | null;
+              activities?: ResearchActivity[];
+              sources?: ResearchSource[];
+              currentDepth?: number;
+              maxDepth?: number;
+              totalUrls?: number;
+              error?: string;
+            };
+          }>(`/v2/deep-research/${id}`);
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              status: data.status ?? 'processing',
+              finalAnalysis: data.finalAnalysis ?? '',
+              json: data.json ?? null,
+              activities: data.activities ?? [],
+              sources: data.sources ?? [],
+              currentDepth: data.currentDepth ?? 0,
+              maxDepth: data.maxDepth ?? 0,
+              totalUrls: data.totalUrls ?? 0,
+              error: data.error ?? null,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch deep research status');
+        }
+      },
+    },
+    llmsTxt: {
+      async generateLlmsTxt(payload) {
+        try {
+          const response = await http.post<{ success: boolean; id: string }>(
+            '/v2/llmstxt',
+            payload,
+          );
+
+          return {
+            data: { id: response.data.id },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to start LLMs.txt generation');
+        }
+      },
+      async getLlmsTxtStatus(id) {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            status?: LlmsTxtStatus['status'];
+            data?: { llmstxt?: string; llmsfulltxt?: string };
+          }>(`/v2/llmstxt/${id}`);
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              status: response.data.status ?? 'processing',
+              llmstxt: data.llmstxt ?? '',
+              llmsfulltxt: data.llmsfulltxt ?? '',
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch LLMs.txt status');
         }
       },
     },

--- a/src/views/BatchScrapeView.vue
+++ b/src/views/BatchScrapeView.vue
@@ -344,7 +344,7 @@ onUnmounted(stopPolling);
   max-width: 700px;
   margin: 1rem auto;
   padding: 1rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font-family: Arial, sans-serif;
 }
@@ -374,13 +374,16 @@ textarea,
 select {
   padding: 0.5rem;
   font-size: 1rem;
-  border: 1px solid #aaa;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
 }
 
 .form-group small {
   font-size: 0.8em;
-  color: #666;
+  color: var(--color-text);
+  opacity: 0.7;
   margin-top: 3px;
 }
 
@@ -443,7 +446,7 @@ select {
 
 .progress-container {
   width: 100%;
-  background-color: #e0e0e0;
+  background-color: var(--color-background-mute);
   border-radius: 5px;
   margin: 10px 0;
   overflow: hidden;
@@ -458,9 +461,9 @@ select {
 .batch-errors-section {
   margin: 1.5rem 0;
   padding: 15px;
-  border: 1px solid #f0c0c0;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  background: #fff7f7;
+  background: var(--color-background-soft);
 }
 
 .errors-list {

--- a/src/views/BatchScrapeView.vue
+++ b/src/views/BatchScrapeView.vue
@@ -1,0 +1,353 @@
+<template>
+  <div class="page-container batch-scrape-view">
+    <h2>Batch Scrape</h2>
+    <p class="intro">Scrape multiple URLs in a single job and track progress.</p>
+
+    <form class="batch-form" @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="urls">URLs (one per line):</label>
+        <textarea
+          id="urls"
+          v-model="urlsInput"
+          rows="6"
+          placeholder="https://example.com&#10;https://example.org/page"
+          required
+        ></textarea>
+        <small>Each non-empty line is treated as a URL to scrape.</small>
+      </div>
+
+      <div class="form-group">
+        <label for="formats">Output Formats:</label>
+        <select id="formats" v-model="selectedFormats" multiple>
+          <option value="markdown">Markdown</option>
+          <option value="html">HTML</option>
+          <option value="rawHtml">Raw HTML</option>
+          <option value="links">Links</option>
+          <option value="summary">Summary</option>
+          <option value="screenshot">Screenshot (Viewport)</option>
+          <option value="screenshot@fullPage">Screenshot (Full Page)</option>
+        </select>
+        <small>Select one or more formats.</small>
+      </div>
+
+      <label class="checkbox-label">
+        <input type="checkbox" v-model="onlyMainContent" />
+        Only Main Content (exclude headers, footers, etc.)
+      </label>
+
+      <button type="submit" class="primary-button" :disabled="loading">
+        {{ loading ? 'Submitting…' : 'Start Batch Scrape' }}
+      </button>
+    </form>
+
+    <div v-if="error" class="error">{{ error }}</div>
+
+    <!-- Progress while the batch job is running -->
+    <div v-if="jobId" class="status-section">
+      <h3>Batch Status</h3>
+      <p>Job ID: {{ jobId }}</p>
+      <p>Status: {{ status }}</p>
+      <div class="progress-container">
+        <div class="progress-bar" :style="{ width: progress + '%' }"></div>
+      </div>
+      <p>{{ completed }} / {{ total }} pages scraped ({{ progress }}%)</p>
+      <p v-if="creditsUsed">Credits used: {{ creditsUsed }}</p>
+    </div>
+
+    <!-- Results once the batch is completed -->
+    <div v-if="results.length" class="results">
+      <h3>Results ({{ results.length }})</h3>
+      <ul class="result-list">
+        <li v-for="(doc, index) in results" :key="index">
+          {{ docTitle(doc) }}
+        </li>
+      </ul>
+      <button class="download-button" type="button" @click="downloadJson">Download JSON</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, inject, onUnmounted } from 'vue';
+import type { FirecrawlBatchScrapingApi } from '@/services/firecrawl';
+
+/**
+ * BatchScrapeView Component
+ *
+ * Lets the user submit several URLs as a single batch scrape job, polls the job
+ * status until completion, and renders the scraped documents with a JSON export.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * @type {{ batchScraping?: FirecrawlBatchScrapingApi } | undefined}
+ */
+const api = inject('api') as { batchScraping?: FirecrawlBatchScrapingApi } | undefined;
+if (!api?.batchScraping) {
+  throw new Error(
+    'Batch scraping API is not available. Ensure the API plugin is correctly configured.',
+  );
+}
+
+/** Raw multiline textarea content holding one URL per line. */
+const urlsInput = ref('');
+/** Selected output formats for the scrape. */
+const selectedFormats = ref<string[]>(['markdown']);
+/** Whether to restrict extraction to the main content of each page. */
+const onlyMainContent = ref(true);
+
+/** Whether a submission request is currently in flight. */
+const loading = ref(false);
+/** User-facing error message. */
+const error = ref('');
+
+/** Identifier of the running batch job, or null when idle. */
+const jobId = ref<string | null>(null);
+/** Current job status label. */
+const status = ref('');
+/** Number of pages scraped so far. */
+const completed = ref(0);
+/** Total number of pages in the job. */
+const total = ref(0);
+/** Completion percentage derived from completed/total. */
+const progress = ref(0);
+/** Number of credits consumed by the job. */
+const creditsUsed = ref(0);
+/** Scraped documents returned once the job completes. */
+const results = ref<Record<string, unknown>[]>([]);
+
+/** Polling interval handle. */
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Derive a human-readable label from a scraped document.
+ *
+ * @param doc - The scraped document record.
+ * @returns The document title, source URL, or a fallback string.
+ */
+function docTitle(doc: Record<string, unknown>): string {
+  const metadata = (doc.metadata as Record<string, unknown> | undefined) ?? {};
+  return (
+    (metadata.title as string | undefined) ||
+    (metadata.sourceURL as string | undefined) ||
+    (doc.url as string | undefined) ||
+    'Untitled document'
+  );
+}
+
+/**
+ * Stop the status polling loop, if any is active.
+ */
+function stopPolling(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Poll the batch scrape status endpoint until the job completes or fails.
+ *
+ * @param id - The batch job identifier.
+ */
+function pollStatus(id: string): void {
+  stopPolling();
+  intervalId = setInterval(async () => {
+    try {
+      const response = await api.batchScraping!.getBatchScrapeStatus(id);
+      const data = response.data;
+      status.value = data.status;
+      completed.value = data.completed;
+      total.value = data.total;
+      creditsUsed.value = data.creditsUsed;
+      progress.value = data.total > 0 ? Math.round((data.completed / data.total) * 100) : 0;
+
+      if (data.status === 'completed' || data.status === 'failed') {
+        results.value = data.data;
+        stopPolling();
+      }
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch batch status.';
+      status.value = 'failed';
+      stopPolling();
+    }
+  }, 3000);
+}
+
+/**
+ * Submit the batch scrape job from the current form inputs and start polling.
+ *
+ * @returns {Promise<void>} Resolves once the job has been submitted.
+ */
+async function handleSubmit(): Promise<void> {
+  const urls = urlsInput.value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (urls.length === 0) {
+    error.value = 'Please enter at least one URL.';
+    return;
+  }
+  if (selectedFormats.value.length === 0) {
+    error.value = 'Please select at least one output format.';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  results.value = [];
+  jobId.value = null;
+  try {
+    const response = await api.batchScraping!.batchScrape({
+      urls,
+      formats: selectedFormats.value,
+      onlyMainContent: onlyMainContent.value,
+    });
+    jobId.value = response.data.id;
+    status.value = 'scraping';
+    pollStatus(response.data.id);
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to start batch scrape.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+/**
+ * Download the scraped documents as a JSON file.
+ */
+function downloadJson(): void {
+  const blob = new Blob([JSON.stringify(results.value, null, 2)], { type: 'application/json' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = `batch-scrape-${jobId.value ?? 'results'}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+// Clean up the polling loop when the component is destroyed.
+onUnmounted(stopPolling);
+</script>
+
+<style scoped>
+.batch-scrape-view {
+  max-width: 700px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.batch-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+textarea,
+select {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+
+.form-group small {
+  font-size: 0.8em;
+  color: #666;
+  margin-top: 3px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: normal;
+}
+
+.primary-button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-section {
+  margin-top: 1.5rem;
+}
+
+.progress-container {
+  width: 100%;
+  background-color: #e0e0e0;
+  border-radius: 5px;
+  margin: 10px 0;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 20px;
+  background-color: #4caf50;
+  transition: width 0.5s ease;
+}
+
+.results {
+  margin-top: 1.5rem;
+}
+
+.result-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  word-break: break-all;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/views/BatchScrapeView.vue
+++ b/src/views/BatchScrapeView.vue
@@ -52,6 +52,38 @@
       </div>
       <p>{{ completed }} / {{ total }} pages scraped ({{ progress }}%)</p>
       <p v-if="creditsUsed">Credits used: {{ creditsUsed }}</p>
+      <div class="status-actions">
+        <!-- Cancel button: visible only while the job is actively running -->
+        <button
+          v-if="isJobRunning"
+          class="cancel-button"
+          type="button"
+          :disabled="cancelling"
+          @click="cancelJob"
+        >
+          {{ cancelling ? 'Cancelling…' : 'Cancel' }}
+        </button>
+        <!-- Check Errors button: visible whenever a job ID exists -->
+        <button class="download-button" type="button" @click="loadErrors">Check Errors</button>
+      </div>
+    </div>
+
+    <!-- Section listing scrape errors for the current batch job -->
+    <div v-if="errorsLoaded" class="batch-errors-section">
+      <h3>Batch Errors</h3>
+      <p v-if="batchErrors.length === 0 && batchRobotsBlocked.length === 0">No errors reported.</p>
+      <ul v-if="batchErrors.length > 0" class="errors-list">
+        <li v-for="(err, index) in batchErrors" :key="err.id || index">
+          <strong>{{ err.url || 'Unknown URL' }}</strong> — {{ err.error || 'Unknown error' }}
+          <em v-if="err.timestamp"> ({{ new Date(err.timestamp).toLocaleString() }})</em>
+        </li>
+      </ul>
+      <div v-if="batchRobotsBlocked.length > 0">
+        <h4>Blocked by robots.txt</h4>
+        <ul class="errors-list">
+          <li v-for="(url, index) in batchRobotsBlocked" :key="index">{{ url }}</li>
+        </ul>
+      </div>
     </div>
 
     <!-- Results once the batch is completed -->
@@ -68,14 +100,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, onUnmounted } from 'vue';
-import type { FirecrawlBatchScrapingApi } from '@/services/firecrawl';
+import { ref, computed, inject, onUnmounted } from 'vue';
+import type { CrawlError, FirecrawlBatchScrapingApi } from '@/services/firecrawl';
 
 /**
  * BatchScrapeView Component
  *
  * Lets the user submit several URLs as a single batch scrape job, polls the job
  * status until completion, and renders the scraped documents with a JSON export.
+ * Also supports cancelling an in-progress job and fetching the error report.
  */
 
 /**
@@ -116,8 +149,30 @@ const creditsUsed = ref(0);
 /** Scraped documents returned once the job completes. */
 const results = ref<Record<string, unknown>[]>([]);
 
+/** Whether a cancel request is currently in flight. */
+const cancelling = ref(false);
+
+/** Errors reported for the current batch job. */
+const batchErrors = ref<CrawlError[]>([]);
+/** URLs blocked by robots.txt for the current batch job. */
+const batchRobotsBlocked = ref<string[]>([]);
+/** Whether the error report has been fetched at least once for the current job. */
+const errorsLoaded = ref(false);
+
 /** Polling interval handle. */
 let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * True while the job is actively scraping or processing (i.e. not yet in a
+ * terminal state). Used to control the visibility of the Cancel button.
+ */
+const isJobRunning = computed(
+  () =>
+    jobId.value !== null &&
+    status.value !== 'completed' &&
+    status.value !== 'failed' &&
+    status.value !== 'cancelled',
+);
 
 /**
  * Derive a human-readable label from a scraped document.
@@ -198,6 +253,9 @@ async function handleSubmit(): Promise<void> {
   error.value = '';
   results.value = [];
   jobId.value = null;
+  errorsLoaded.value = false;
+  batchErrors.value = [];
+  batchRobotsBlocked.value = [];
   try {
     const response = await api.batchScraping!.batchScrape({
       urls,
@@ -211,6 +269,55 @@ async function handleSubmit(): Promise<void> {
     error.value = err instanceof Error ? err.message : 'Failed to start batch scrape.';
   } finally {
     loading.value = false;
+  }
+}
+
+/**
+ * Cancel the currently running batch scrape job.
+ *
+ * Calls the cancel endpoint, stops polling, and sets the status to 'cancelled'.
+ * Any API error is surfaced through the existing error ref.
+ *
+ * @returns {Promise<void>} Resolves once the cancel request completes.
+ */
+async function cancelJob(): Promise<void> {
+  if (!jobId.value) {
+    return;
+  }
+  cancelling.value = true;
+  error.value = '';
+  try {
+    await api.batchScraping!.cancelBatchScrape(jobId.value);
+    stopPolling();
+    status.value = 'cancelled';
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to cancel batch scrape job.';
+  } finally {
+    cancelling.value = false;
+  }
+}
+
+/**
+ * Fetch the error report for the current batch job and populate the errors section.
+ *
+ * Both `batchErrors` and `batchRobotsBlocked` are updated; `errorsLoaded` is
+ * set to true so the errors section becomes visible. Any API error is surfaced
+ * through the existing error ref.
+ *
+ * @returns {Promise<void>} Resolves once the error report has been fetched.
+ */
+async function loadErrors(): Promise<void> {
+  if (!jobId.value) {
+    return;
+  }
+  error.value = '';
+  try {
+    const response = await api.batchScraping!.getBatchScrapeErrors(jobId.value);
+    batchErrors.value = response.data.errors;
+    batchRobotsBlocked.value = response.data.robotsBlocked;
+    errorsLoaded.value = true;
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to fetch batch scrape errors.';
   }
 }
 
@@ -308,6 +415,32 @@ select {
   margin-top: 1.5rem;
 }
 
+.status-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.cancel-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #dc3545;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cancel-button:hover:not(:disabled) {
+  background-color: #b02a37;
+}
+
+.cancel-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .progress-container {
   width: 100%;
   background-color: #e0e0e0;
@@ -320,6 +453,20 @@ select {
   height: 20px;
   background-color: #4caf50;
   transition: width 0.5s ease;
+}
+
+.batch-errors-section {
+  margin: 1.5rem 0;
+  padding: 15px;
+  border: 1px solid #f0c0c0;
+  border-radius: 4px;
+  background: #fff7f7;
+}
+
+.errors-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  word-break: break-all;
 }
 
 .results {

--- a/src/views/BillingView.vue
+++ b/src/views/BillingView.vue
@@ -1,0 +1,213 @@
+<template>
+  <div class="page-container billing-view">
+    <h2>Billing &amp; Credits</h2>
+    <p class="intro">Check the remaining Firecrawl credits available for your team.</p>
+
+    <button type="button" class="primary-button" :disabled="loading" @click="fetchUsage">
+      {{ loading ? 'Loading…' : 'Refresh credit usage' }}
+    </button>
+
+    <div v-if="error" class="error">{{ error }}</div>
+    <div v-else-if="loading" class="status">Loading…</div>
+
+    <div v-else-if="usage" class="results">
+      <div class="credit-cards">
+        <div class="credit-card highlight">
+          <span class="credit-label">Remaining credits</span>
+          <span class="credit-value">{{ formatNumber(usage.remainingCredits) }}</span>
+        </div>
+        <div v-if="usage.planCredits != null" class="credit-card">
+          <span class="credit-label">Plan credits</span>
+          <span class="credit-value">{{ formatNumber(usage.planCredits) }}</span>
+        </div>
+      </div>
+
+      <div v-if="usage.billingPeriodStart || usage.billingPeriodEnd" class="billing-period">
+        <h3>Billing period</h3>
+        <p>
+          <span v-if="usage.billingPeriodStart">{{ usage.billingPeriodStart }}</span>
+          <span v-if="usage.billingPeriodStart && usage.billingPeriodEnd"> → </span>
+          <span v-if="usage.billingPeriodEnd">{{ usage.billingPeriodEnd }}</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, inject, onMounted } from 'vue';
+import type { CreditUsage, FirecrawlBillingApi } from '@/services/firecrawl';
+
+/**
+ * BillingView Component
+ *
+ * Displays the team's Firecrawl credit usage. It fetches the remaining credits
+ * (and, when available, plan credits and the current billing period) from the
+ * billing API adapter exposed by the API plugin.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * This instance is expected to contain a `billing` property for credit queries.
+ * @type {{ billing?: FirecrawlBillingApi } | undefined}
+ */
+const api = inject('api') as { billing?: FirecrawlBillingApi } | undefined;
+if (!api?.billing) {
+  throw new Error(
+    'Billing API is not available. Ensure the API plugin is correctly configured and provides the billing service.',
+  );
+}
+
+/**
+ * Reactive credit usage data returned by the API, or `null` before the first load.
+ * @type {Ref<CreditUsage | null>}
+ */
+const usage = ref<CreditUsage | null>(null);
+
+/**
+ * Reactive flag indicating whether a request is currently in progress.
+ * @type {Ref<boolean>}
+ */
+const loading = ref(false);
+
+/**
+ * Reactive error message displayed when a request fails.
+ * @type {Ref<string>}
+ */
+const error = ref('');
+
+/**
+ * Format a numeric credit value with thousands separators for readability.
+ *
+ * @param value - The numeric value to format, or `null` when unavailable.
+ * @returns A localized string, or a dash when the value is missing.
+ */
+function formatNumber(value: number | null | undefined): string {
+  return typeof value === 'number' ? value.toLocaleString() : '—';
+}
+
+/**
+ * Fetch the current credit usage from the billing API and update local state.
+ * Manages the loading and error states around the request.
+ *
+ * @returns {Promise<void>} A promise that resolves once the request completes.
+ */
+async function fetchUsage(): Promise<void> {
+  loading.value = true;
+  error.value = '';
+  try {
+    const response = await api.billing!.getCreditUsage();
+    usage.value = response.data;
+  } catch (err: unknown) {
+    error.value =
+      err instanceof Error ? err.message : 'Failed to fetch credit usage. Please try again.';
+    usage.value = null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Automatically load credit usage when the view is mounted.
+onMounted(fetchUsage);
+</script>
+
+<style scoped>
+/* Main container for the BillingView component. */
+.billing-view {
+  max-width: 600px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+/* Introductory description text. */
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+/* Primary action button. */
+.primary-button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Results section wrapping the credit cards. */
+.results {
+  margin-top: 1.5rem;
+}
+
+/* Layout for the credit summary cards. */
+.credit-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+/* Individual credit card. */
+.credit-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  min-width: 160px;
+  background: #f8f9fb;
+}
+
+/* Emphasized card for the primary metric. */
+.credit-card.highlight {
+  border-color: #007acc;
+  background: #eaf4fb;
+}
+
+/* Small label above each credit value. */
+.credit-label {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+/* Prominent numeric credit value. */
+.credit-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #007acc;
+}
+
+/* Billing period block. */
+.billing-period {
+  margin-top: 1.5rem;
+}
+
+.billing-period h3 {
+  margin-bottom: 0.25rem;
+}
+
+/* Error message styling. */
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+
+/* Status (loading) message styling. */
+.status {
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/views/BillingView.vue
+++ b/src/views/BillingView.vue
@@ -133,7 +133,7 @@ onMounted(fetchUsage);
   max-width: 600px;
   margin: 1rem auto;
   padding: 1rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font-family: Arial, sans-serif;
 }
@@ -182,16 +182,16 @@ onMounted(fetchUsage);
   flex-direction: column;
   gap: 0.4rem;
   padding: 1rem 1.25rem;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   min-width: 160px;
-  background: #f8f9fb;
+  background: var(--color-background-soft);
 }
 
 /* Emphasized card for the primary metric. */
 .credit-card.highlight {
   border-color: #007acc;
-  background: #eaf4fb;
+  background: var(--color-background-mute);
 }
 
 /* Small label above each credit value. */

--- a/src/views/BillingView.vue
+++ b/src/views/BillingView.vue
@@ -20,6 +20,10 @@
           <span class="credit-label">Plan credits</span>
           <span class="credit-value">{{ formatNumber(usage.planCredits) }}</span>
         </div>
+        <div v-if="tokenUsage" class="credit-card">
+          <span class="credit-label">Remaining tokens (Extract)</span>
+          <span class="credit-value">{{ formatNumber(tokenUsage.remainingTokens) }}</span>
+        </div>
       </div>
 
       <div v-if="usage.billingPeriodStart || usage.billingPeriodEnd" class="billing-period">
@@ -36,7 +40,7 @@
 
 <script setup lang="ts">
 import { ref, inject, onMounted } from 'vue';
-import type { CreditUsage, FirecrawlBillingApi } from '@/services/firecrawl';
+import type { CreditUsage, TokenUsage, FirecrawlBillingApi } from '@/services/firecrawl';
 
 /**
  * BillingView Component
@@ -63,6 +67,12 @@ if (!api?.billing) {
  * @type {Ref<CreditUsage | null>}
  */
 const usage = ref<CreditUsage | null>(null);
+
+/**
+ * Reactive token usage data (Extract feature), or `null` before the first load.
+ * @type {Ref<TokenUsage | null>}
+ */
+const tokenUsage = ref<TokenUsage | null>(null);
 
 /**
  * Reactive flag indicating whether a request is currently in progress.
@@ -96,12 +106,18 @@ async function fetchUsage(): Promise<void> {
   loading.value = true;
   error.value = '';
   try {
-    const response = await api.billing!.getCreditUsage();
-    usage.value = response.data;
+    // Fetch credit and token usage together; both belong to the Billing tag.
+    const [creditResponse, tokenResponse] = await Promise.all([
+      api.billing!.getCreditUsage(),
+      api.billing!.getTokenUsage(),
+    ]);
+    usage.value = creditResponse.data;
+    tokenUsage.value = tokenResponse.data;
   } catch (err: unknown) {
     error.value =
-      err instanceof Error ? err.message : 'Failed to fetch credit usage. Please try again.';
+      err instanceof Error ? err.message : 'Failed to fetch usage information. Please try again.';
     usage.value = null;
+    tokenUsage.value = null;
   } finally {
     loading.value = false;
   }

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -373,7 +373,34 @@
       </div>
       <p>{{ progress }}% Completed</p>
       <p>{{ pagesCompleted }} / {{ totalPages }} pages processed</p>
-      <button class="primary-button" type="button" @click="cancelCurrentCrawl">Cancel Crawl</button>
+      <div class="crawl-status-actions">
+        <button class="primary-button" type="button" @click="cancelCurrentCrawl">
+          Cancel Crawl
+        </button>
+        <button class="download-button" type="button" @click="loadCrawlErrors()">
+          Check Errors
+        </button>
+      </div>
+    </div>
+
+    <!-- Section listing scrape errors for the current crawl -->
+    <div v-if="crawlErrorsLoaded" class="crawl-errors-section">
+      <h3>Crawl Errors</h3>
+      <p v-if="crawlErrors.length === 0 && robotsBlocked.length === 0">
+        No errors reported for this crawl.
+      </p>
+      <ul v-if="crawlErrors.length > 0" class="errors-list">
+        <li v-for="(err, index) in crawlErrors" :key="err.id || index">
+          <strong>{{ err.url || 'Unknown URL' }}</strong> — {{ err.error || 'Unknown error' }}
+          <em v-if="err.timestamp"> ({{ new Date(err.timestamp).toLocaleString() }})</em>
+        </li>
+      </ul>
+      <div v-if="robotsBlocked.length > 0">
+        <h4>Blocked by robots.txt</h4>
+        <ul class="errors-list">
+          <li v-for="(url, index) in robotsBlocked" :key="index">{{ url }}</li>
+        </ul>
+      </div>
     </div>
 
     <!-- Section for download options after crawl completion -->
@@ -482,6 +509,7 @@ import { saveAs } from 'file-saver';
 import axios from 'axios';
 import { useRouter } from 'vue-router';
 import {
+  type CrawlError,
   type FirecrawlCrawlingApi,
   type FirecrawlExtractionApi,
   type FirecrawlMappingApi,
@@ -829,6 +857,11 @@ export default defineComponent({
     // State for selected crawl history item
     const selectedCrawlId = ref<string | null>(null);
     const simulatedFiles = ref<string[]>([]);
+
+    // State for the crawl errors report.
+    const crawlErrors = ref<CrawlError[]>([]);
+    const robotsBlocked = ref<string[]>([]);
+    const crawlErrorsLoaded = ref(false);
 
     // LocalStorage key for crawl history
     const HISTORY_STORAGE_KEY = 'crawlHistory';
@@ -1432,6 +1465,26 @@ export default defineComponent({
       }
     };
 
+    /**
+     * Fetch and display the error report for the active (or selected) crawl job.
+     * Falls back across the current job id, result id and selected history id.
+     */
+    const loadCrawlErrors = async (): Promise<void> => {
+      const jobId = currentCrawlId.value || result.value?.id || selectedCrawlId.value;
+      if (!jobId) {
+        error.value = 'No crawl job available to fetch errors.';
+        return;
+      }
+      try {
+        const response = await api.crawling.getCrawlErrors(jobId);
+        crawlErrors.value = response.data.errors;
+        robotsBlocked.value = response.data.robotsBlocked;
+        crawlErrorsLoaded.value = true;
+      } catch (err: any) {
+        error.value = `Failed to fetch crawl errors: ${err.message || 'Unknown error'}`;
+      }
+    };
+
     // Interval ID for polling crawl status
     let intervalId: ReturnType<typeof setInterval> | null = null;
     const historyIntervalIds: Record<string, ReturnType<typeof setInterval>> = {};
@@ -1624,6 +1677,10 @@ export default defineComponent({
       result,
       handleSubmit,
       cancelCurrentCrawl,
+      loadCrawlErrors,
+      crawlErrors,
+      robotsBlocked,
+      crawlErrorsLoaded,
       isCrawlerOptionsCollapsed,
       isScrapeOptionsCollapsed,
       isWebhookOptionsCollapsed,
@@ -1747,6 +1804,27 @@ export default defineComponent({
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+}
+
+.crawl-status-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.crawl-errors-section {
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #f0c0c0;
+  border-radius: 4px;
+  background: #fff7f7;
+}
+
+.errors-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  word-break: break-all;
 }
 
 .crawl-history-section li {

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -472,6 +472,30 @@
       <button class="primary-button" @click="selectedCrawlId = null">Hide Details</button>
     </div>
 
+    <!-- Section for active crawls fetched from the API -->
+    <div class="active-crawls-section">
+      <div class="active-crawls-header">
+        <h2>Active Crawls</h2>
+        <button class="primary-button" type="button" @click="loadActiveCrawls">Refresh</button>
+      </div>
+      <div v-if="activeCrawls.length > 0">
+        <ul class="history-list">
+          <li v-for="crawl in activeCrawls" :key="crawl.id" class="history-item">
+            <span class="history-info">
+              <strong>{{ crawl.url || '—' }}</strong>
+              – ID: {{ crawl.id }}
+            </span>
+            <button class="history-button" type="button" @click.prevent="selectCrawl(crawl.id)">
+              View
+            </button>
+          </li>
+        </ul>
+      </div>
+      <div v-else>
+        <p>No active crawls.</p>
+      </div>
+    </div>
+
     <!-- Section for crawl history -->
     <div class="crawl-history-section">
       <h2>Crawl History</h2>
@@ -509,6 +533,7 @@ import { saveAs } from 'file-saver';
 import axios from 'axios';
 import { useRouter } from 'vue-router';
 import {
+  type ActiveCrawl,
   type CrawlError,
   type FirecrawlCrawlingApi,
   type FirecrawlExtractionApi,
@@ -862,6 +887,9 @@ export default defineComponent({
     const crawlErrors = ref<CrawlError[]>([]);
     const robotsBlocked = ref<string[]>([]);
     const crawlErrorsLoaded = ref(false);
+
+    // State for active crawls fetched from the API.
+    const activeCrawls = ref<ActiveCrawl[]>([]);
 
     // LocalStorage key for crawl history
     const HISTORY_STORAGE_KEY = 'crawlHistory';
@@ -1485,6 +1513,23 @@ export default defineComponent({
       }
     };
 
+    /**
+     * Fetch the list of currently active crawl jobs from the API.
+     * Populates the `activeCrawls` ref on success; routes errors into the
+     * existing `error` ref so the user sees a consistent error banner.
+     *
+     * @returns {Promise<void>} Resolves when the request completes or fails.
+     */
+    const loadActiveCrawls = async (): Promise<void> => {
+      error.value = '';
+      try {
+        const response = await api.crawling.getActiveCrawls();
+        activeCrawls.value = response.data.crawls;
+      } catch (err: any) {
+        error.value = `Failed to fetch active crawls: ${err.message || 'Unknown error'}`;
+      }
+    };
+
     // Interval ID for polling crawl status
     let intervalId: ReturnType<typeof setInterval> | null = null;
     const historyIntervalIds: Record<string, ReturnType<typeof setInterval>> = {};
@@ -1699,6 +1744,8 @@ export default defineComponent({
       useSubfolders,
       statusCheckInterval,
       clearHistory,
+      activeCrawls,
+      loadActiveCrawls,
       // Expose saveHistory if needed elsewhere, though not strictly necessary for this task
       // saveHistory,
     };
@@ -1825,6 +1872,21 @@ export default defineComponent({
   list-style: disc;
   padding-left: 1.5rem;
   word-break: break-all;
+}
+
+.active-crawls-section {
+  margin: 20px 0;
+}
+
+.active-crawls-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.active-crawls-header h2 {
+  margin: 0;
 }
 
 .crawl-history-section li {

--- a/src/views/ExtractView.vue
+++ b/src/views/ExtractView.vue
@@ -54,6 +54,16 @@
       </button>
     </form>
 
+    <div class="form-group resume-group">
+      <label for="resume-id-input">Resume by Job ID</label>
+      <div class="resume-row">
+        <input id="resume-id-input" v-model="resumeId" type="text" placeholder="Extract job ID" />
+        <button type="button" class="primary-button" :disabled="loading" @click="resumeExtraction">
+          Fetch Result
+        </button>
+      </div>
+    </div>
+
     <div v-if="loading && !result" class="status">Extracting...</div>
     <div v-if="error" class="status error">{{ error }}</div>
     <div v-if="result" class="result">
@@ -87,6 +97,7 @@ const error = ref(''); // Stores any error messages from the extraction process.
 const result = ref<FirecrawlExtractResponse['data'] | null>(null); // Stores the successful extraction result.
 const schemaError = ref<string | null>(null); // Stores error messages related to JSON schema parsing.
 const parsedSchema = ref<any>(undefined); // Holds the parsed schema object.
+const resumeId = ref(''); // Stores the job ID entered by the user for resuming an extract job.
 
 /**
  * Watcher to parse the schema string and update the parsed schema.
@@ -147,6 +158,53 @@ const runExtraction = async (): Promise<void> => {
       result.value = (respData as any).data;
     } else {
       throw new Error((respData as any).error || 'Extraction failed');
+    }
+  } catch (err: any) {
+    error.value = err?.message || 'Request failed';
+    result.value = null;
+  } finally {
+    loading.value = false;
+  }
+};
+
+/**
+ * Fetch the result of a previously submitted extract job by its ID.
+ *
+ * Calls `getExtractStatus` with the trimmed `resumeId`. If the job has
+ * completed and carries data, the result is displayed using the existing
+ * result section. If the job is still processing, a message is surfaced in
+ * the error display so the user knows to try again. If the job failed or
+ * returned no useful payload, the API error (or a generic fallback) is shown.
+ *
+ * @returns A promise that resolves when the status fetch and state update
+ *   are complete.
+ */
+const resumeExtraction = async (): Promise<void> => {
+  const id = resumeId.value.trim();
+  if (!id) {
+    error.value = 'Please enter an extract job ID.';
+    return;
+  }
+
+  try {
+    loading.value = true;
+    error.value = '';
+    result.value = null;
+
+    const response = await api.extraction.getExtractStatus(id);
+    const respData = response.data;
+
+    if (respData.status === 'processing') {
+      error.value = 'Job still processing, try again.';
+    } else if (respData.status === 'failed') {
+      throw new Error(respData.error || 'Extract job failed');
+    } else if (respData.status === 'completed' && respData.data) {
+      result.value = respData.data as FirecrawlExtractResponse['data'];
+    } else if ((respData as any).data) {
+      // No explicit status but data is present — treat as completed.
+      result.value = (respData as any).data;
+    } else {
+      throw new Error(respData.error || 'No data returned for this job ID');
     }
   } catch (err: any) {
     error.value = err?.message || 'Request failed';
@@ -251,5 +309,25 @@ pre {
   display: block;
   margin-top: 4px;
   color: #666;
+}
+
+.resume-group {
+  margin-top: 20px;
+  padding-top: 15px;
+  border-top: 1px solid #eee;
+}
+
+.resume-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.resume-row input[type='text'] {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: 'Courier New', Courier, monospace;
 }
 </style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -41,6 +41,12 @@
       </div>
       <div class="feature-card">
         <IconSupport class="icon" />
+        <h2>Billing</h2>
+        <p>Monitor your team's remaining Firecrawl credits and plan usage.</p>
+        <router-link to="/billing" class="feature-link">View Billing</router-link>
+      </div>
+      <div class="feature-card">
+        <IconSupport class="icon" />
         <h2>API Configuration</h2>
         <p>Configure your API keys and access points for custom workflows.</p>
         <router-link to="/api-config" class="feature-link">Configure API</router-link>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -46,6 +46,18 @@
         <router-link to="/search" class="feature-link">Access Search</router-link>
       </div>
       <div class="feature-card">
+        <IconTooling class="icon" />
+        <h2>Deep Research</h2>
+        <p>Run an autonomous multi-step research agent over the web on any query.</p>
+        <router-link to="/research" class="feature-link">Access Deep Research</router-link>
+      </div>
+      <div class="feature-card">
+        <IconDocumentation class="icon" />
+        <h2>LLMs.txt</h2>
+        <p>Generate an llms.txt summary of a website for use with LLMs.</p>
+        <router-link to="/llmstxt" class="feature-link">Generate LLMs.txt</router-link>
+      </div>
+      <div class="feature-card">
         <IconSupport class="icon" />
         <h2>Billing</h2>
         <p>Monitor your team's remaining Firecrawl credits and plan usage.</p>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -16,6 +16,12 @@
         <router-link to="/scrape" class="feature-link">Access Scraping</router-link>
       </div>
       <div class="feature-card">
+        <IconDocumentation class="icon" />
+        <h2>Batch Scrape</h2>
+        <p>Scrape multiple URLs at once and track the job until completion.</p>
+        <router-link to="/batch-scrape" class="feature-link">Access Batch Scrape</router-link>
+      </div>
+      <div class="feature-card">
         <IconEcosystem class="icon" />
         <h2>Crawl</h2>
         <p>Explore websites in depth and collect data on a large scale.</p>

--- a/src/views/LlmsTxtView.vue
+++ b/src/views/LlmsTxtView.vue
@@ -228,7 +228,7 @@ onUnmounted(stopPolling);
   max-width: 700px;
   margin: 1rem auto;
   padding: 1rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font-family: Arial, sans-serif;
 }
@@ -258,13 +258,16 @@ input[type='url'],
 input[type='number'] {
   padding: 0.5rem;
   font-size: 1rem;
-  border: 1px solid #aaa;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
 }
 
 .form-group small {
   font-size: 0.8em;
-  color: #666;
+  color: var(--color-text);
+  opacity: 0.7;
   margin-top: 3px;
 }
 
@@ -301,7 +304,8 @@ input[type='number'] {
 
 .generating-status {
   font-style: italic;
-  color: #555;
+  color: var(--color-text);
+  opacity: 0.7;
 }
 
 .results {
@@ -312,7 +316,7 @@ input[type='number'] {
 }
 
 .result-block {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -322,8 +326,8 @@ input[type='number'] {
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 1rem;
-  background-color: #f5f5f5;
-  border-bottom: 1px solid #ddd;
+  background-color: var(--color-background-soft);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .result-header h3 {
@@ -339,7 +343,8 @@ input[type='number'] {
   padding: 1rem;
   margin: 0;
   font-size: 0.85rem;
-  background-color: #fafafa;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
   font-family: monospace;
 }
 

--- a/src/views/LlmsTxtView.vue
+++ b/src/views/LlmsTxtView.vue
@@ -1,0 +1,374 @@
+<template>
+  <div class="page-container llms-txt-view">
+    <h2>LLMs.txt Generator</h2>
+    <p class="intro">Generate an LLMs.txt (and optionally full-text) file from any website.</p>
+
+    <form class="llms-form" @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="url">URL:</label>
+        <input id="url" v-model="url" type="url" placeholder="https://example.com" required />
+        <small>The website URL to generate an LLMs.txt file for.</small>
+      </div>
+
+      <div class="form-group">
+        <label for="maxUrls">Max URLs:</label>
+        <input id="maxUrls" v-model.number="maxUrls" type="number" min="1" placeholder="2" />
+        <small>Maximum number of URLs to include in the output.</small>
+      </div>
+
+      <label class="checkbox-label">
+        <input type="checkbox" v-model="showFullText" />
+        Generate full-text version (llms-full.txt)
+      </label>
+
+      <button type="submit" class="primary-button" :disabled="loading">
+        {{ loading ? 'Submitting…' : 'Generate LLMs.txt' }}
+      </button>
+    </form>
+
+    <div v-if="error" class="error">{{ error }}</div>
+
+    <!-- Status while the job is processing -->
+    <div v-if="jobId && generationStatus === 'processing'" class="status-section">
+      <p class="generating-status">Generating… (Job ID: {{ jobId }})</p>
+    </div>
+
+    <!-- Failed state -->
+    <div v-if="generationStatus === 'failed'" class="error">
+      Generation failed. Please try again.
+    </div>
+
+    <!-- Results once the job completes -->
+    <div v-if="generationStatus === 'completed'" class="results">
+      <div class="result-block">
+        <div class="result-header">
+          <h3>llms.txt</h3>
+          <button class="download-button" type="button" @click="downloadLlmsTxt">
+            Download llms.txt
+          </button>
+        </div>
+        <pre class="result-pre">{{ llmstxt }}</pre>
+      </div>
+
+      <div v-if="llmsfulltxt" class="result-block">
+        <div class="result-header">
+          <h3>
+            <button
+              class="collapsible-toggle"
+              type="button"
+              @click="fullTextExpanded = !fullTextExpanded"
+            >
+              {{ fullTextExpanded ? '▾' : '▸' }} llms-full.txt
+            </button>
+          </h3>
+          <button class="download-button" type="button" @click="downloadLlmsFullTxt">
+            Download llms-full.txt
+          </button>
+        </div>
+        <pre v-if="fullTextExpanded" class="result-pre">{{ llmsfulltxt }}</pre>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, inject, onUnmounted } from 'vue';
+import type { FirecrawlLlmsTxtApi, LlmsTxtStatus } from '@/services/firecrawl';
+
+/**
+ * LlmsTxtView Component
+ *
+ * Lets the user submit a URL to generate an LLMs.txt (and optionally a
+ * full-text) file via the Firecrawl API, polls the job status until
+ * completion, and renders the results with download buttons.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * @type {{ llmsTxt?: FirecrawlLlmsTxtApi } | undefined}
+ */
+const api = inject('api') as { llmsTxt?: FirecrawlLlmsTxtApi } | undefined;
+if (!api?.llmsTxt) {
+  throw new Error('LLMs.txt API is not available. Ensure the API plugin is correctly configured.');
+}
+
+/** The website URL to generate the LLMs.txt for. */
+const url = ref('');
+/** Maximum number of URLs to include in the output. */
+const maxUrls = ref<number>(2);
+/** Whether to also generate the full-text version. */
+const showFullText = ref(false);
+
+/** Whether a submission request is currently in flight. */
+const loading = ref(false);
+/** User-facing error message. */
+const error = ref('');
+
+/** Identifier of the running generation job, or null when idle. */
+const jobId = ref<string | null>(null);
+/** Current job status, or null when no job has been started. */
+const generationStatus = ref<LlmsTxtStatus['status'] | null>(null);
+/** Generated llms.txt content. */
+const llmstxt = ref('');
+/** Generated llms-full.txt content, empty when not requested or unavailable. */
+const llmsfulltxt = ref('');
+/** Whether the collapsible full-text block is expanded. */
+const fullTextExpanded = ref(false);
+
+/** Polling interval handle. */
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Stop the status polling loop, if any is active.
+ */
+function stopPolling(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Poll the LLMs.txt status endpoint until the job completes or fails.
+ *
+ * @param id - The generation job identifier.
+ */
+function pollStatus(id: string): void {
+  stopPolling();
+  intervalId = setInterval(async () => {
+    try {
+      const response = await api.llmsTxt!.getLlmsTxtStatus(id);
+      const data = response.data;
+      generationStatus.value = data.status;
+
+      if (data.status === 'completed') {
+        llmstxt.value = data.llmstxt;
+        llmsfulltxt.value = data.llmsfulltxt;
+        stopPolling();
+      } else if (data.status === 'failed') {
+        stopPolling();
+      }
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch generation status.';
+      generationStatus.value = 'failed';
+      stopPolling();
+    }
+  }, 3000);
+}
+
+/**
+ * Submit the LLMs.txt generation job from the current form inputs and start polling.
+ *
+ * @returns {Promise<void>} Resolves once the job has been submitted.
+ */
+async function handleSubmit(): Promise<void> {
+  if (!url.value) {
+    error.value = 'Please enter a URL.';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  jobId.value = null;
+  generationStatus.value = null;
+  llmstxt.value = '';
+  llmsfulltxt.value = '';
+  fullTextExpanded.value = false;
+
+  try {
+    const response = await api.llmsTxt!.generateLlmsTxt({
+      url: url.value,
+      maxUrls: maxUrls.value,
+      showFullText: showFullText.value,
+    });
+    jobId.value = response.data.id;
+    generationStatus.value = 'processing';
+    pollStatus(response.data.id);
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to start LLMs.txt generation.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+/**
+ * Trigger a browser download of the generated llms.txt content.
+ */
+function downloadLlmsTxt(): void {
+  const blob = new Blob([llmstxt.value], { type: 'text/plain' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'llms.txt';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+/**
+ * Trigger a browser download of the generated llms-full.txt content.
+ */
+function downloadLlmsFullTxt(): void {
+  const blob = new Blob([llmsfulltxt.value], { type: 'text/plain' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'llms-full.txt';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+// Clean up the polling loop when the component is destroyed.
+onUnmounted(stopPolling);
+</script>
+
+<style scoped>
+.llms-txt-view {
+  max-width: 700px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.llms-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+input[type='url'],
+input[type='number'] {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+
+.form-group small {
+  font-size: 0.8em;
+  color: #666;
+  margin-top: 3px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: normal;
+}
+
+.primary-button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-section {
+  margin-top: 1.5rem;
+}
+
+.generating-status {
+  font-style: italic;
+  color: #555;
+}
+
+.results {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.result-block {
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #ddd;
+}
+
+.result-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.result-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 1rem;
+  margin: 0;
+  font-size: 0.85rem;
+  background-color: #fafafa;
+  font-family: monospace;
+}
+
+.collapsible-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: bold;
+  padding: 0;
+  color: inherit;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/views/ResearchView.vue
+++ b/src/views/ResearchView.vue
@@ -449,7 +449,7 @@ onUnmounted(stopPolling);
   max-width: 700px;
   margin: 1rem auto;
   padding: 1rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font-family: Arial, sans-serif;
 }
@@ -491,13 +491,16 @@ select,
 input[type='number'] {
   padding: 0.5rem;
   font-size: 1rem;
-  border: 1px solid #aaa;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
 }
 
 .form-group small {
   font-size: 0.8em;
-  color: #666;
+  color: var(--color-text);
+  opacity: 0.7;
   margin-top: 3px;
 }
 
@@ -524,9 +527,9 @@ input[type='number'] {
   flex-direction: column;
   gap: 1rem;
   padding: 0.75rem;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
-  background-color: #fafafa;
+  background-color: var(--color-background-soft);
 }
 
 .primary-button {
@@ -580,7 +583,7 @@ input[type='number'] {
   font-size: 0.9rem;
   padding: 0.25rem 0.5rem;
   border-radius: 3px;
-  background-color: #f5f5f5;
+  background-color: var(--color-background-soft);
 }
 
 .activity-status {
@@ -603,7 +606,8 @@ input[type='number'] {
 }
 
 .status-info {
-  color: #888;
+  color: var(--color-text);
+  opacity: 0.7;
 }
 
 .activity-message {
@@ -612,7 +616,8 @@ input[type='number'] {
 
 .activity-timestamp {
   font-size: 0.75em;
-  color: #999;
+  color: var(--color-text);
+  opacity: 0.6;
   white-space: nowrap;
 }
 
@@ -664,7 +669,8 @@ a.source-title:hover {
 
 .source-description {
   font-size: 0.85rem;
-  color: #555;
+  color: var(--color-text);
+  opacity: 0.7;
   margin: 0;
 }
 
@@ -675,8 +681,8 @@ a.source-title:hover {
 .analysis-content {
   white-space: pre-wrap;
   word-break: break-word;
-  background-color: #f9f9f9;
-  border: 1px solid #ddd;
+  background-color: var(--color-background-mute);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   padding: 1rem;
   font-size: 0.9rem;

--- a/src/views/ResearchView.vue
+++ b/src/views/ResearchView.vue
@@ -1,0 +1,712 @@
+<template>
+  <div class="page-container research-view">
+    <h2>Deep Research</h2>
+    <p class="intro">
+      Run an AI-powered deep research job that crawls the web and synthesises a final analysis.
+    </p>
+
+    <form class="research-form" @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="query">Research Query:</label>
+        <textarea
+          id="query"
+          v-model="query"
+          rows="4"
+          placeholder="What is the current state of quantum computing?"
+          required
+        ></textarea>
+        <small>Describe the topic or question you want researched.</small>
+      </div>
+
+      <!-- Advanced options collapsible block -->
+      <div class="advanced-toggle">
+        <button type="button" class="toggle-button" @click="showAdvanced = !showAdvanced">
+          {{ showAdvanced ? 'Hide' : 'Show' }} Advanced Options
+        </button>
+      </div>
+
+      <div v-if="showAdvanced" class="advanced-options">
+        <div class="form-row">
+          <div class="form-group">
+            <label for="maxDepth">Max Depth (1–12):</label>
+            <input id="maxDepth" v-model.number="maxDepth" type="number" min="1" max="12" />
+            <small>How many research hops to perform.</small>
+          </div>
+
+          <div class="form-group">
+            <label for="timeLimit">Time Limit (seconds, 30–600):</label>
+            <input id="timeLimit" v-model.number="timeLimit" type="number" min="30" max="600" />
+            <small>Maximum wall-clock time for the job.</small>
+          </div>
+
+          <div class="form-group">
+            <label for="maxUrls">Max URLs (1–1000):</label>
+            <input id="maxUrls" v-model.number="maxUrls" type="number" min="1" max="1000" />
+            <small>Cap on total URLs visited.</small>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="analysisPrompt">Analysis Prompt (optional):</label>
+          <textarea
+            id="analysisPrompt"
+            v-model="analysisPrompt"
+            rows="3"
+            placeholder="Focus the final analysis on practical applications."
+          ></textarea>
+          <small>Guide the synthesis step with a custom prompt.</small>
+        </div>
+
+        <div class="form-group">
+          <label for="systemPrompt">System Prompt (optional):</label>
+          <textarea
+            id="systemPrompt"
+            v-model="systemPrompt"
+            rows="3"
+            placeholder="You are an expert researcher. Be concise and cite sources."
+          ></textarea>
+          <small>Override the default system prompt used during research.</small>
+        </div>
+
+        <div class="form-group">
+          <label for="formats">Output Formats:</label>
+          <select id="formats" v-model="selectedFormats" multiple>
+            <option value="markdown">Markdown</option>
+            <option value="json">JSON</option>
+          </select>
+          <small>Select one or more output formats.</small>
+        </div>
+      </div>
+
+      <button type="submit" class="primary-button" :disabled="loading">
+        {{ loading ? 'Starting…' : 'Start Deep Research' }}
+      </button>
+    </form>
+
+    <div v-if="error" class="error">{{ error }}</div>
+
+    <!-- Progress while the research job is processing -->
+    <div v-if="jobId && jobStatus === 'processing'" class="status-section">
+      <h3>Research in Progress</h3>
+      <p>Job ID: {{ jobId }}</p>
+      <p class="progress-line">
+        Depth {{ currentDepth }}/{{ maxDepthReported }} &middot; {{ totalUrls }} URLs visited
+      </p>
+
+      <div v-if="activities.length" class="activities">
+        <h4>Live Activity</h4>
+        <ul class="activity-list">
+          <li v-for="(activity, index) in activitiesNewestFirst" :key="index" class="activity-item">
+            <span class="activity-status" :class="activityClass(activity.status)">
+              {{ activity.status ?? 'info' }}
+            </span>
+            <span class="activity-message">{{ activity.message }}</span>
+            <span v-if="activity.timestamp" class="activity-timestamp">
+              {{ formatTimestamp(activity.timestamp) }}
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Failed state -->
+    <div v-if="jobStatus === 'failed'" class="status-section">
+      <h3>Research Failed</h3>
+      <div class="error">
+        {{ researchError ?? 'The research job encountered an unexpected error.' }}
+      </div>
+    </div>
+
+    <!-- Completed state: sources + final analysis -->
+    <div v-if="jobStatus === 'completed'" class="results">
+      <h3>Research Complete</h3>
+
+      <div v-if="sources.length" class="sources-section">
+        <h4>Sources ({{ sources.length }})</h4>
+        <ul class="source-list">
+          <li v-for="(source, index) in sources" :key="index" class="source-item">
+            <img
+              v-if="source.favicon"
+              :src="source.favicon"
+              alt=""
+              class="source-favicon"
+              aria-hidden="true"
+            />
+            <div class="source-body">
+              <a
+                v-if="source.url"
+                :href="source.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="source-title"
+              >
+                {{ source.title ?? source.url }}
+              </a>
+              <span v-else class="source-title">{{ source.title ?? 'Unknown source' }}</span>
+              <p v-if="source.description" class="source-description">{{ source.description }}</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div v-if="finalAnalysis" class="analysis-section">
+        <h4>Final Analysis</h4>
+        <pre class="analysis-content">{{ finalAnalysis }}</pre>
+      </div>
+
+      <div class="download-buttons">
+        <button
+          v-if="finalAnalysis"
+          type="button"
+          class="download-button"
+          @click="downloadMarkdown"
+        >
+          Download Markdown
+        </button>
+        <button
+          v-if="researchJson !== null"
+          type="button"
+          class="download-button"
+          @click="downloadJson"
+        >
+          Download JSON
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, inject, onUnmounted } from 'vue';
+import type {
+  FirecrawlResearchApi,
+  DeepResearchStatus,
+  ResearchActivity,
+  ResearchSource,
+} from '@/services/firecrawl';
+
+/**
+ * ResearchView Component
+ *
+ * Lets the user submit a deep research query, polls the job status until
+ * completion, and renders the final analysis and discovered sources with
+ * download options.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * @type {{ research?: FirecrawlResearchApi } | undefined}
+ */
+const api = inject('api') as { research?: FirecrawlResearchApi } | undefined;
+if (!api?.research) {
+  throw new Error('Research API is not available. Ensure the API plugin is correctly configured.');
+}
+
+// --- Form state ---
+
+/** The main research question entered by the user. */
+const query = ref('');
+/** Whether the advanced options block is expanded. */
+const showAdvanced = ref(false);
+/** Maximum research depth (1–12). */
+const maxDepth = ref(7);
+/** Time limit in seconds (30–600). */
+const timeLimit = ref(300);
+/** Maximum number of URLs to visit (1–1000). */
+const maxUrls = ref(20);
+/** Optional custom analysis prompt. */
+const analysisPrompt = ref('');
+/** Optional custom system prompt. */
+const systemPrompt = ref('');
+/** Selected output formats. */
+const selectedFormats = ref<string[]>(['markdown']);
+
+// --- Async / job state ---
+
+/** Whether a submission request is currently in flight. */
+const loading = ref(false);
+/** User-facing error message for submission failures. */
+const error = ref('');
+
+/** Identifier of the running research job, or null when idle. */
+const jobId = ref<string | null>(null);
+/** Current job lifecycle status. */
+const jobStatus = ref<DeepResearchStatus['status'] | null>(null);
+/** Current crawl depth reported by the server. */
+const currentDepth = ref(0);
+/** Max depth as reported by the server status response. */
+const maxDepthReported = ref(0);
+/** Total URLs visited so far. */
+const totalUrls = ref(0);
+/** Live activity log from the server. */
+const activities = ref<ResearchActivity[]>([]);
+/** Discovered sources once the job completes. */
+const sources = ref<ResearchSource[]>([]);
+/** Final analysis text once the job completes. */
+const finalAnalysis = ref('');
+/** JSON result from the server, if any. */
+const researchJson = ref<Record<string, unknown> | null>(null);
+/** Error message reported by the server on failure. */
+const researchError = ref<string | null>(null);
+
+/** Polling interval handle. */
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+// --- Computed ---
+
+/**
+ * Returns the activities list sorted newest-first for display.
+ */
+const activitiesNewestFirst = computed<ResearchActivity[]>(() => [...activities.value].reverse());
+
+// --- Helpers ---
+
+/**
+ * Stop the status polling loop, if any is active.
+ */
+function stopPolling(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Apply a server status response snapshot to the reactive state.
+ *
+ * @param data - The deep research status object returned by the API.
+ */
+function applyStatus(data: DeepResearchStatus): void {
+  jobStatus.value = data.status;
+  currentDepth.value = data.currentDepth;
+  maxDepthReported.value = data.maxDepth;
+  totalUrls.value = data.totalUrls;
+  activities.value = data.activities;
+
+  if (data.status === 'completed') {
+    sources.value = data.sources;
+    finalAnalysis.value = data.finalAnalysis;
+    researchJson.value = data.json;
+  }
+
+  if (data.status === 'failed') {
+    researchError.value = data.error;
+  }
+}
+
+/**
+ * Poll the deep research status endpoint until the job completes or fails.
+ *
+ * @param id - The research job identifier.
+ */
+function pollStatus(id: string): void {
+  stopPolling();
+  intervalId = setInterval(async () => {
+    try {
+      const response = await api.research!.getDeepResearchStatus(id);
+      applyStatus(response.data);
+
+      if (response.data.status === 'completed' || response.data.status === 'failed') {
+        stopPolling();
+      }
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch research status.';
+      jobStatus.value = 'failed';
+      stopPolling();
+    }
+  }, 3000);
+}
+
+/**
+ * Build a CSS class name based on the activity status string for colour coding.
+ *
+ * @param status - The activity status value (may be undefined).
+ * @returns A CSS class string.
+ */
+function activityClass(status: string | undefined): string {
+  switch (status) {
+    case 'completed':
+      return 'status-completed';
+    case 'failed':
+      return 'status-failed';
+    case 'processing':
+      return 'status-processing';
+    default:
+      return 'status-info';
+  }
+}
+
+/**
+ * Format an ISO 8601 timestamp into a compact, locale-aware time string.
+ *
+ * @param timestamp - An ISO 8601 timestamp string.
+ * @returns A short time string suitable for the activity list.
+ */
+function formatTimestamp(timestamp: string): string {
+  try {
+    return new Date(timestamp).toLocaleTimeString();
+  } catch {
+    return timestamp;
+  }
+}
+
+/**
+ * Trigger a browser file download for the given content.
+ *
+ * @param content - The file content as a string.
+ * @param filename - The suggested download filename.
+ * @param mimeType - The MIME type of the file.
+ */
+function triggerDownload(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+/**
+ * Download the final analysis as a Markdown file.
+ */
+function downloadMarkdown(): void {
+  triggerDownload(
+    finalAnalysis.value,
+    `deep-research-${jobId.value ?? 'result'}.md`,
+    'text/markdown',
+  );
+}
+
+/**
+ * Download the JSON result as a JSON file.
+ */
+function downloadJson(): void {
+  if (researchJson.value === null) {
+    return;
+  }
+  triggerDownload(
+    JSON.stringify(researchJson.value, null, 2),
+    `deep-research-${jobId.value ?? 'result'}.json`,
+    'application/json',
+  );
+}
+
+/**
+ * Submit the deep research job from the current form inputs and start polling.
+ *
+ * @returns {Promise<void>} Resolves once the job has been submitted.
+ */
+async function handleSubmit(): Promise<void> {
+  if (!query.value.trim()) {
+    error.value = 'Please enter a research query.';
+    return;
+  }
+  if (selectedFormats.value.length === 0) {
+    error.value = 'Please select at least one output format.';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  jobId.value = null;
+  jobStatus.value = null;
+  activities.value = [];
+  sources.value = [];
+  finalAnalysis.value = '';
+  researchJson.value = null;
+  researchError.value = null;
+
+  const payload: Record<string, unknown> = {
+    query: query.value.trim(),
+    maxDepth: maxDepth.value,
+    timeLimit: timeLimit.value,
+    maxUrls: maxUrls.value,
+    formats: selectedFormats.value,
+    ...(analysisPrompt.value.trim() ? { analysisPrompt: analysisPrompt.value.trim() } : {}),
+    ...(systemPrompt.value.trim() ? { systemPrompt: systemPrompt.value.trim() } : {}),
+  };
+
+  try {
+    const response = await api.research!.startDeepResearch(payload);
+    jobId.value = response.data.id;
+    jobStatus.value = 'processing';
+    pollStatus(response.data.id);
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to start deep research.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Clean up the polling loop when the component is destroyed.
+onUnmounted(stopPolling);
+</script>
+
+<style scoped>
+.research-view {
+  max-width: 700px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.research-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.form-row .form-group {
+  flex: 1;
+  min-width: 140px;
+}
+
+label {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+textarea,
+select,
+input[type='number'] {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+
+.form-group small {
+  font-size: 0.8em;
+  color: #666;
+  margin-top: 3px;
+}
+
+.advanced-toggle {
+  margin-top: -0.25rem;
+}
+
+.toggle-button {
+  background: none;
+  border: none;
+  color: #007acc;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.toggle-button:hover {
+  color: #005fa3;
+}
+
+.advanced-options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background-color: #fafafa;
+}
+
+.primary-button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-section {
+  margin-top: 1.5rem;
+}
+
+.progress-line {
+  font-weight: bold;
+  color: #007acc;
+}
+
+.activities {
+  margin-top: 1rem;
+}
+
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.activity-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  background-color: #f5f5f5;
+}
+
+.activity-status {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.7em;
+  white-space: nowrap;
+}
+
+.status-completed {
+  color: #4caf50;
+}
+
+.status-failed {
+  color: #d9534f;
+}
+
+.status-processing {
+  color: #007acc;
+}
+
+.status-info {
+  color: #888;
+}
+
+.activity-message {
+  flex: 1;
+}
+
+.activity-timestamp {
+  font-size: 0.75em;
+  color: #999;
+  white-space: nowrap;
+}
+
+.results {
+  margin-top: 1.5rem;
+}
+
+.sources-section {
+  margin-bottom: 1.5rem;
+}
+
+.source-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.source-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.source-favicon {
+  width: 16px;
+  height: 16px;
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+
+.source-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.source-title {
+  font-weight: bold;
+  color: #007acc;
+  word-break: break-word;
+}
+
+a.source-title:hover {
+  text-decoration: underline;
+}
+
+.source-description {
+  font-size: 0.85rem;
+  color: #555;
+  margin: 0;
+}
+
+.analysis-section {
+  margin-bottom: 1rem;
+}
+
+.analysis-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.download-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+</style>


### PR DESCRIPTION
## Summary

Completes UI + service-adapter coverage for the remaining Firecrawl **v2** API surface. Every v2 operation now has a wired adapter in `src/services/firecrawl.ts` and a corresponding UI.

New views:
- **Deep Research** (`/research`) — `POST /v2/deep-research` + status polling, live activities, sources, final analysis, Markdown/JSON download.
- **LLMs.txt** (`/llmstxt`) — `POST /v2/llmstxt` + status polling, renders `llmstxt`/`llmsfulltxt` with downloads.
- **Billing** (`/billing`) — credit usage + Extract token usage (`GET /v2/team/credit-usage`, `GET /v2/team/token-usage`).

Extended existing views:
- **Batch Scrape** — multi-URL batch job, polling, cancel (`DELETE /v2/batch/scrape/{id}`) and error reporting (`.../errors`).
- **Crawl** — list active crawls (`GET /v2/crawl/active`), cancel, crawl error report.
- **Extract** — resume an extract job by ID (`GET /v2/extract/{id}`).

Wiring: routes added in `src/router/index.ts`, feature cards added to `src/views/HomeView.vue`.

## Test plan

- `npx prettier --check "src/**/*.{ts,vue}"` — clean
- `npx eslint src` — clean
- `npm run build` — succeeds (138 modules transformed)
- Manual: each new route (`/research`, `/llmstxt`, `/billing`) and the cancel/errors/active/resume controls with a valid API key in localStorage.

Note: no automated tests exist in this project (`npm test` is a no-op); type-checking relies on eslint + the Vite build, as elsewhere in the repo.
