### PR TITLE
[firecrawl-ui] Fix Extract: poll the async job for its result

### DIFF
--- a/src/services/firecrawl.ts
+++ b/src/services/firecrawl.ts
@@ -488,16 +488,29 @@ async function waitForExtract(
   http: AxiosInstance,
   initialResponse: FirecrawlExtractResponse,
 ): Promise<FirecrawlExtractResponse> {
-  if (!initialResponse.id || !initialResponse.status || initialResponse.status !== 'processing') {
+  // When the API answers synchronously the data is already present and there is
+  // no job to poll. Otherwise the async POST only returns { success, id } with
+  // no `status` field on v2, so a missing status still means "keep polling".
+  if (!initialResponse.id || initialResponse.data !== undefined) {
     return initialResponse;
   }
 
-  let response = initialResponse;
+  // Terminal job states: stop polling as soon as one of these is reached.
+  const terminalStatuses = new Set(['completed', 'failed', 'cancelled']);
+  // Bound the loop (~2 minutes at 1s interval) so a job that never settles
+  // cannot hang the UI indefinitely.
+  const maxAttempts = 120;
 
-  while (response.status === 'processing' && response.id) {
+  let response = initialResponse;
+  let attempts = 0;
+
+  while (!terminalStatuses.has(response.status ?? '') && attempts < maxAttempts) {
     await sleep(1000);
-    const pollResponse = await http.get<FirecrawlExtractResponse>(`/v2/extract/${response.id}`);
+    const pollResponse = await http.get<FirecrawlExtractResponse>(
+      `/v2/extract/${initialResponse.id}`,
+    );
     response = pollResponse.data;
+    attempts += 1;
   }
 
   return response;


### PR DESCRIPTION
## Summary

Extract reported a generic "Extraction failed" on Firecrawl v2 instances. The cause is in the API adapter: `POST /v2/extract` answers asynchronously with just `{ success: true, id }` and **no** `status` field, but the old polling guard only kept polling when `status === 'processing'`. With no status on the initial response, it returned the job stub immediately, the view saw no `data`, and surfaced the failure.

The fix makes `waitForExtract` poll `GET /v2/extract/{id}` whenever a job id is present and no inline data came back, stopping on a terminal status (`completed`, `failed`, `cancelled`) or after a bounded number of attempts so a stuck job cannot hang the UI. The endpoint stays `/v2/extract` on purpose: migrating to `/v2/scrape` with a json format would drop multi-URL and prompt-only extraction.

## Test plan

- `npm ci` then `npm run build` succeeds
- `npx prettier --check .` and `npx eslint .` pass
- Manual: open Extract, provide a URL plus a prompt or schema, submit, and confirm structured data renders instead of "Extraction failed". (UI click-test still pending: the local browser driver cannot settle on the animated aurora background, so this last step needs a human pass.)