### PR TITLE
[firecrawl-ui] Default the Map sitemap mode to include

### DIFF
--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -160,11 +160,15 @@ onMounted(() => {
 const search = ref('');
 
 /**
- * Reactive variable to control whether the website sitemap should be ignored during crawling.
- * Defaults to `true`.
- * @type {Ref<boolean>}
+ * Reactive variable holding the sitemap strategy sent to the `/v2/map` endpoint.
+ *
+ * Defaults to `include`, matching the API default: the sitemap is the only link
+ * source a self-hosted Firecrawl instance can rely on, so defaulting to `skip`
+ * made every map request return an empty list there.
+ *
+ * @type {Ref<'include' | 'skip' | 'only'>}
  */
-const sitemapMode = ref<'include' | 'skip' | 'only'>('skip');
+const sitemapMode = ref<'include' | 'skip' | 'only'>('include');
 
 /**
  * Reactive variable to control whether subdomains of the website should be included in the mapping.


### PR DESCRIPTION
## Problem

The Map tool returns nothing on a self-hosted Firecrawl instance: HTTP 200, no error, empty result panel.

The Map view initialises `sitemapMode` to `skip`, so every request goes out with `sitemap: "skip"`. The hosted API survives that because it falls back on its own link index. A self-hosted instance has no such index, which leaves the sitemap as its only link source, so skipping it means there is nothing left to return.

## Fix

Default to `include`, which is also the API default. The dropdown still offers `skip` and `only` for anyone who wants them.

The JSDoc above the ref was stale too (it described a boolean defaulting to `true`, a leftover from the old `ignoreSitemap` flag) and now documents the actual enum plus the reason for the default.

## Verification

`POST /v2/map` against a self-hosted instance, target `https://firecrawl.dev`, `limit: 10`, same API key, only the sitemap mode changing:

| `sitemap` | links returned |
| --- | --- |
| `skip` | 0 |
| `include` | 10 |
| `only` | 10 |

`npx prettier --check`, `npx eslint` and `npm run build` all pass.