### PR TITLE
[firecrawl-ui] Add a copy URL list action to Map

### DIFF
--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -98,8 +98,9 @@
       <CodeBlock v-else-if="activeTab === 'json'" :json="urls" label="JSON" />
     </template>
 
-    <!-- ── Response actions: download button in tab bar ───────────────── -->
+    <!-- ── Response actions: copy + download buttons in tab bar ───────── -->
     <template #response-actions>
+      <CopyButton v-if="hasResult" :text="urlListText" label="Copy URL list" />
       <button v-if="hasResult" type="button" class="download-btn" @click="downloadJson">
         Download JSON
       </button>
@@ -222,6 +223,12 @@ const durationMs = ref<number | null>(null);
  * and the visibility of the download button.
  */
 const hasResult = computed<boolean>(() => urls.value.length > 0);
+
+/**
+ * The result as plain text, one URL per line, ready to be dropped in a .txt
+ * file or piped into another tool. Backs the "Copy URL list" action.
+ */
+const urlListText = computed<string>(() => urls.value.join('\n'));
 
 /**
  * Status bar text: URL count on success, 'Error' on failure, null while idle.


### PR DESCRIPTION
## What

The Map response tab bar gains a **Copy URL list** button next to Download JSON. It copies the result as plain text, one URL per line, so it can go straight into a `.txt` file, a shell pipe or an editor without stripping JSON brackets and quotes by hand.

## How

- `urlListText` computed: `urls.join('\n')`
- Reuses the shared `CopyButton`, same as ScrapeView does in its own `#response-actions` slot, so the copied confirmation state and the silent fallback on an unavailable Clipboard API come for free
- Shown only when there is a result, matching the download button

## Note on the base branch

This is stacked on `fix/map-sitemap-default` (#97), because without that fix the Map view returns nothing on a self-hosted instance and there is no list to copy. Merge #97 first and this one retargets to `main` on its own.

## Checks

`npx prettier --check`, `npx eslint` and `npm run build` pass. Exercised through the Vite dev server with HMR, no console warnings after the change.