### PR TITLE
chore(deps): add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 06:00
+      time: '06:00'
       timezone: Europe/Paris
     open-pull-requests-limit: 5
     labels:
@@ -27,7 +27,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 06:00
+      time: '06:00'
       timezone: Europe/Paris
     open-pull-requests-limit: 5
     labels:
@@ -51,7 +51,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 06:00
+      time: '06:00'
       timezone: Europe/Paris
     open-pull-requests-limit: 5
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,70 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+    time: 06:00
+    timezone: Europe/Paris
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  commit-message:
+    prefix: chore(deps)
+  groups:
+    actions-minor-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    actions-major:
+      applies-to: version-updates
+      update-types:
+      - major
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+    time: 06:00
+    timezone: Europe/Paris
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  commit-message:
+    prefix: chore(deps)
+    prefix-development: chore(deps-dev)
+    include: scope
+  groups:
+    npm-minor-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    npm-major:
+      applies-to: version-updates
+      update-types:
+      - major
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: weekly
+    day: monday
+    time: 06:00
+    timezone: Europe/Paris
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  commit-message:
+    prefix: chore(deps)
+  groups:
+    docker-minor-patch:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
+    docker-major:
+      applies-to: version-updates
+      update-types:
+      - major

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,70 +1,70 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-    time: 06:00
-    timezone: Europe/Paris
-  open-pull-requests-limit: 5
-  labels:
-  - dependencies
-  commit-message:
-    prefix: chore(deps)
-  groups:
-    actions-minor-patch:
-      applies-to: version-updates
-      update-types:
-      - minor
-      - patch
-    actions-major:
-      applies-to: version-updates
-      update-types:
-      - major
-- package-ecosystem: npm
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-    time: 06:00
-    timezone: Europe/Paris
-  open-pull-requests-limit: 5
-  labels:
-  - dependencies
-  commit-message:
-    prefix: chore(deps)
-    prefix-development: chore(deps-dev)
-    include: scope
-  groups:
-    npm-minor-patch:
-      applies-to: version-updates
-      update-types:
-      - minor
-      - patch
-    npm-major:
-      applies-to: version-updates
-      update-types:
-      - major
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-    time: 06:00
-    timezone: Europe/Paris
-  open-pull-requests-limit: 5
-  labels:
-  - dependencies
-  commit-message:
-    prefix: chore(deps)
-  groups:
-    docker-minor-patch:
-      applies-to: version-updates
-      update-types:
-      - minor
-      - patch
-    docker-major:
-      applies-to: version-updates
-      update-types:
-      - major
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: 06:00
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        applies-to: version-updates
+        update-types:
+          - major
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: 06:00
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+      include: scope
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+      npm-major:
+        applies-to: version-updates
+        update-types:
+          - major
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: 06:00
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      docker-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+      docker-major:
+        applies-to: version-updates
+        update-types:
+          - major

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        # dependabot/fetch-metadata v3.1.0, pinned to commit SHA
+        # https://github.com/dependabot/fetch-metadata/releases/tag/v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and enable auto-merge for patch/minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
         # https://github.com/dependabot/fetch-metadata/releases/tag/v3.1.0
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Approve and enable auto-merge for patch/minor updates
         if: |


### PR DESCRIPTION
Adds a weekly, grouped Dependabot config for this repo's detected ecosystems, plus an auto-merge workflow for patch/minor updates once checks pass. Generated by rollout.sh.