### PR TITLE
[firecrawl-ui] Stop labelling LLM-backed formats as cloud-only

### DIFF
--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -172,10 +172,10 @@
                 <option value="rawHtml">Raw HTML</option>
                 <option value="links">Links</option>
                 <option value="images">Images</option>
-                <option value="summary">Summary *</option>
+                <option value="summary">Summary †</option>
                 <option value="screenshot">Screenshot (Viewport)</option>
                 <option value="screenshot@fullPage">Screenshot (Full Page)</option>
-                <option value="json">JSON *</option>
+                <option value="json">JSON †</option>
                 <option value="attributes">Attributes</option>
                 <option value="branding">Branding *</option>
                 <option value="changeTracking">Change Tracking *</option>
@@ -258,21 +258,21 @@
               />
             </div>
             <div class="form-group">
-              <label for="jsonSchema">JSON Options Schema (JSON) *:</label>
+              <label for="jsonSchema">JSON Options Schema (JSON) †:</label>
               <textarea id="jsonSchema" v-model="jsonOptionsSchemaInput"></textarea>
               <div v-if="jsonOptionsSchemaError" class="error-message">
                 {{ jsonOptionsSchemaError }}
               </div>
             </div>
             <div class="form-group">
-              <label for="jsonSystemPrompt">JSON System Prompt *:</label>
+              <label for="jsonSystemPrompt">JSON System Prompt †:</label>
               <textarea
                 id="jsonSystemPrompt"
                 v-model="formData.scrapeOptions.jsonOptions.systemPrompt"
               ></textarea>
             </div>
             <div class="form-group">
-              <label for="jsonPrompt">JSON Prompt *:</label>
+              <label for="jsonPrompt">JSON Prompt †:</label>
               <textarea
                 id="jsonPrompt"
                 v-model="formData.scrapeOptions.jsonOptions.prompt"
@@ -362,6 +362,10 @@
         <p class="api-note">
           * Available only on the official Firecrawl cloud API. These options may be ignored or
           unsupported on self-hosted instances.
+        </p>
+        <p class="api-note">
+          † LLM-backed. Works on a self-hosted instance once it has an OpenAI-compatible provider or
+          Ollama configured.
         </p>
 
         <button type="submit" class="primary-button">Submit Crawl</button>

--- a/src/views/ScrapeView.vue
+++ b/src/views/ScrapeView.vue
@@ -27,10 +27,10 @@
             <option value="rawHtml">Raw HTML</option>
             <option value="links">Links</option>
             <option value="images">Images</option>
-            <option value="summary">Summary *</option>
+            <option value="summary">Summary †</option>
             <option value="screenshot">Screenshot (Viewport)</option>
             <option value="screenshot@fullPage">Screenshot (Full Page)</option>
-            <option value="json">JSON (Structured Extraction) *</option>
+            <option value="json">JSON (Structured Extraction) †</option>
             <option value="attributes">Attributes</option>
             <option value="branding">Branding *</option>
             <option value="changeTracking">Change Tracking (Requires Markdown) *</option>
@@ -295,7 +295,7 @@
           v-if="formData.scrapeOptions.formats.includes('json')"
           class="form-group options-fieldset"
         >
-          <legend>JSON Format (Structured Extraction) *</legend>
+          <legend>JSON Format (Structured Extraction) †</legend>
           <small class="fieldset-hint">
             Replaces the deprecated /v2/extract endpoint. Provide a prompt, a JSON schema, or both
             to extract structured data with an LLM.
@@ -342,6 +342,10 @@
         <p class="api-note">
           * Available only on the official Firecrawl cloud API. These options may be ignored or
           unsupported on self-hosted instances.
+        </p>
+        <p class="api-note">
+          † LLM-backed. Works on a self-hosted instance once it has an OpenAI-compatible provider or
+          Ollama configured.
         </p>
 
         <button type="submit" class="primary-button">Scrape</button>


### PR DESCRIPTION
Both `ScrapeView` and `CrawlView` marked a handful of options with a `*` and explained it once at the bottom of the form:

> \* Available only on the official Firecrawl cloud API. These options may be ignored or unsupported on self-hosted instances.

For the JSON structured extraction and Summary formats that claim is simply wrong, and it is the kind of wrong that makes people stop trying. The [self-hosting docs](https://docs.firecrawl.dev/contributing/self-host) list LLM-backed extraction and formats as available self-hosted, with one condition: connect an OpenAI-compatible provider or Ollama. It is a provider requirement, not a cloud exclusivity.

Checked against a self-hosted instance rather than taken on faith: a `/v2/extract` call with a JSON schema came back with the right structured object in about three seconds.

## What changed

The single marker becomes two.

- `*` keeps its current meaning and its current members. Branding, change tracking, store in cache, lockdown, redact PII, zero data retention, proxy and location all stay exactly as they were, because I could not verify them either way and guessing is what got us here.
- `†` is new, for LLM-backed options, with the condition they actually have: `JSON (Structured Extraction)` and `Summary` in both views, plus the JSON schema, system prompt and prompt fields in `CrawlView` that configure the same extraction.

> † LLM-backed. Works on a self-hosted instance once it has an OpenAI-compatible provider or Ollama configured.

No behaviour change, no payload change: labels and one added footnote paragraph per view, reusing the existing `.api-note` class.

`prettier --check`, `eslint` and `npm run build` are clean.
