### PR TITLE
[firecrawl-ui] Drop the Actions self-approval from Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,12 +20,14 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Approve and enable auto-merge for patch/minor updates
+      # No `gh pr review --approve` here: approving would require granting
+      # Actions the right to approve pull requests, and no review is required
+      # to merge anyway. `--auto` queues the merge until the checks pass.
+      - name: Enable auto-merge for patch/minor updates
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
The Dependabot auto-merge workflow has failed on every PR since it landed. On #110, a plain group of 11 patch and minor bumps with a green CI, the job died on:

```
failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)
```

That is a repository setting, off by default. Turning it on would let any workflow in this repo approve pull requests, including its own, which is a bigger door than this feature needs. No review is required to merge here in the first place, so the approval was never doing anything except failing.

So the `gh pr review --approve` line goes, and `gh pr merge --auto --squash` stays. It queues the merge and GitHub lands it once the required checks pass, which is the actual behaviour we wanted.

One setting did have to change: repository auto-merge was disabled, and `--auto` cannot work without it. It is now on. `can_approve_pull_request_reviews` stays off.

Nothing else moves: the `dependabot[bot]` actor guard, the pinned `fetch-metadata` action and the patch/minor-only condition are untouched, so major updates still wait for a human.
