### PR TITLE
[firecrawl-ui] Complete Firecrawl v2 coverage, with a /v1 fallback for self-hosted installs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,6 +41,15 @@ const tools: ToolTab[] = [
     ],
   },
   {
+    to: '/batch-scrape',
+    label: 'Batch Scrape',
+    paths: [
+      // Two overlapping rounded rectangles (a "copy" glyph) to signal scraping many URLs at once.
+      'M10 8h10a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z',
+      'M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2',
+    ],
+  },
+  {
     to: '/crawl',
     label: 'Crawl',
     paths: [
@@ -73,6 +82,27 @@ const tools: ToolTab[] = [
     to: '/search',
     label: 'Search',
     paths: ['M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16z', 'm21 21-4.3-4.3'],
+  },
+  {
+    to: '/research',
+    label: 'Research',
+    paths: [
+      // A magnifying glass with a nested inner ring, reading as a "deeper" search.
+      'M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16z',
+      'M11 14.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z',
+      'm21 21-4.3-4.3',
+    ],
+  },
+  {
+    to: '/llmstxt',
+    label: 'LLMs.txt',
+    paths: [
+      // Same file base as Scrape, with "<>" chevrons marking a machine-readable text file.
+      'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z',
+      'M14 2v6h6',
+      'm11 13-2 2 2 2',
+      'm13 13 2 2-2 2',
+    ],
   },
 ];
 
@@ -135,6 +165,12 @@ function toggleTheme(): void {
               <path
                 d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1.08-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1.08 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
               />
+            </svg>
+          </RouterLink>
+          <RouterLink to="/billing" class="icon-btn" aria-label="Billing" title="Billing">
+            <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+              <rect width="20" height="14" x="2" y="5" rx="2" />
+              <line x1="2" x2="22" y1="10" y2="10" />
             </svg>
           </RouterLink>
           <RouterLink to="/about" class="icon-btn" aria-label="About" title="About">

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,11 +1,15 @@
 import { createRouter, createWebHashHistory } from 'vue-router';
 import HomeView from '../views/HomeView.vue';
 import ScrapeView from '../views/ScrapeView.vue';
+import BatchScrapeView from '../views/BatchScrapeView.vue';
 import CrawlView from '../views/CrawlView.vue';
 import ApiConfigView from '../views/ApiConfigView.vue';
 import ExtractView from '../views/ExtractView.vue'; // Import the new view
 import MapView from '../components/MapView.vue';
 import SearchView from '../components/SearchView.vue';
+import ResearchView from '../views/ResearchView.vue';
+import LlmsTxtView from '../views/LlmsTxtView.vue';
+import BillingView from '../views/BillingView.vue';
 import AboutView from '../views/AboutView.vue';
 
 const router = createRouter({
@@ -20,6 +24,11 @@ const router = createRouter({
       path: '/scrape',
       name: 'scrape',
       component: ScrapeView, // Route for the web scraping functionality.
+    },
+    {
+      path: '/batch-scrape',
+      name: 'batch-scrape',
+      component: BatchScrapeView, // Route for the batch scraping functionality.
     },
     {
       path: '/crawl',
@@ -45,6 +54,21 @@ const router = createRouter({
       path: '/search',
       name: 'search',
       component: SearchView, // Route for the search functionality view.
+    },
+    {
+      path: '/research',
+      name: 'research',
+      component: ResearchView, // Route for the deep research functionality.
+    },
+    {
+      path: '/llmstxt',
+      name: 'llmstxt',
+      component: LlmsTxtView, // Route for the LLMs.txt generation view.
+    },
+    {
+      path: '/billing',
+      name: 'billing',
+      component: BillingView, // Route for the billing and credit usage view.
     },
     {
       path: '/about',

--- a/src/services/firecrawl.ts
+++ b/src/services/firecrawl.ts
@@ -271,13 +271,16 @@ export interface DeepResearchStatus {
   maxDepth: number;
   totalUrls: number;
   error: string | null;
+  apiVersion: FirecrawlApiVersion;
 }
 
 /**
  * Legacy-compatible deep research client.
  */
 export interface FirecrawlResearchApi {
-  startDeepResearch(payload: Record<string, unknown>): Promise<WrappedResponse<{ id: string }>>;
+  startDeepResearch(
+    payload: Record<string, unknown>,
+  ): Promise<WrappedResponse<{ id: string; apiVersion: FirecrawlApiVersion }>>;
   getDeepResearchStatus(id: string): Promise<WrappedResponse<DeepResearchStatus>>;
 }
 
@@ -288,13 +291,16 @@ export interface LlmsTxtStatus {
   status: 'processing' | 'completed' | 'failed';
   llmstxt: string;
   llmsfulltxt: string;
+  apiVersion: FirecrawlApiVersion;
 }
 
 /**
  * Legacy-compatible LLMs.txt generation client.
  */
 export interface FirecrawlLlmsTxtApi {
-  generateLlmsTxt(payload: Record<string, unknown>): Promise<WrappedResponse<{ id: string }>>;
+  generateLlmsTxt(
+    payload: Record<string, unknown>,
+  ): Promise<WrappedResponse<{ id: string; apiVersion: FirecrawlApiVersion }>>;
   getLlmsTxtStatus(id: string): Promise<WrappedResponse<LlmsTxtStatus>>;
 }
 
@@ -346,6 +352,96 @@ function createHttpClient(apiKey: string, baseUrl: string): AxiosInstance {
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
     },
   });
+}
+
+/**
+ * Firecrawl API versions this adapter can target, in order of preference.
+ */
+const API_VERSION_PREFERENCE = ['v2', 'v1'] as const;
+
+/**
+ * A Firecrawl API version prefix used to build request paths.
+ */
+export type FirecrawlApiVersion = (typeof API_VERSION_PREFERENCE)[number];
+
+/**
+ * Features whose endpoints are not served by every Firecrawl deployment.
+ *
+ * Firecrawl Cloud exposes deep research and LLMs.txt generation under `/v2`;
+ * self-hosted installs only serve them under `/v1` and answer `/v2` with a
+ * 404. Every other endpoint this adapter uses exists under `/v2` on both.
+ */
+type VersionedFeature = 'deep-research' | 'llmstxt';
+
+/**
+ * Records, per feature, which API version the connected instance answers on.
+ *
+ * This is a correctness requirement, not only an optimization: a job started
+ * against one version must be polled on that same version.
+ */
+type FeatureVersionCache = Map<VersionedFeature, FirecrawlApiVersion>;
+
+/**
+ * Tell whether an error is an HTTP 404, meaning the endpoint is not exposed.
+ *
+ * @param error - The error thrown by an Axios request.
+ * @returns True when the response status is 404.
+ */
+function isEndpointMissing(error: unknown): boolean {
+  return axios.isAxiosError(error) && error.response?.status === 404;
+}
+
+/**
+ * Run a request against the first API version the instance actually serves.
+ *
+ * The resolved version is cached for the lifetime of the client so later calls
+ * skip the probe, and so status polls reach the version that started the job.
+ *
+ * @param cache - The per-client feature version cache.
+ * @param feature - The feature whose endpoint availability varies.
+ * @param send - Callback issuing the request for a given API version.
+ * @returns The result of the first successful attempt.
+ * @throws The original error when it is not a missing-endpoint 404, or the
+ * last 404 when no candidate version is served.
+ */
+async function requestWithVersionFallback<T>(
+  cache: FeatureVersionCache,
+  feature: VersionedFeature,
+  send: (version: FirecrawlApiVersion) => Promise<T>,
+): Promise<T> {
+  const resolvedVersion = cache.get(feature);
+
+  if (resolvedVersion) {
+    return send(resolvedVersion);
+  }
+
+  let lastError: unknown;
+
+  for (const version of API_VERSION_PREFERENCE) {
+    try {
+      const result = await send(version);
+
+      cache.set(feature, version);
+
+      if (version !== API_VERSION_PREFERENCE[0]) {
+        // Surface the downgrade: self-hosted installs land here on every run.
+        console.info(
+          `[firecrawl] "${feature}" is not exposed under /${API_VERSION_PREFERENCE[0]}; ` +
+            `falling back to /${version} (self-hosted install).`,
+        );
+      }
+
+      return result;
+    } catch (error) {
+      if (!isEndpointMissing(error)) {
+        throw error;
+      }
+
+      lastError = error;
+    }
+  }
+
+  throw lastError;
 }
 
 /**
@@ -683,6 +779,7 @@ async function waitForExtract(
  */
 export function createFirecrawlApiClients(apiKey: string, baseUrl: string): FirecrawlApiClients {
   const http = createHttpClient(apiKey, baseUrl);
+  const featureVersions: FeatureVersionCache = new Map();
 
   return {
     billing: {
@@ -956,50 +1053,63 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
     research: {
       async startDeepResearch(payload) {
         try {
-          const response = await http.post<{ success: boolean; id: string }>(
-            '/v2/deep-research',
-            payload,
-          );
+          return await requestWithVersionFallback(
+            featureVersions,
+            'deep-research',
+            async (version) => {
+              const response = await http.post<{ success: boolean; id: string }>(
+                `/${version}/deep-research`,
+                payload,
+              );
 
-          return {
-            data: { id: response.data.id },
-          };
+              return {
+                data: { id: response.data.id, apiVersion: version },
+              };
+            },
+          );
         } catch (error) {
           throw formatApiError(error, 'Failed to start deep research');
         }
       },
       async getDeepResearchStatus(id) {
         try {
-          const response = await http.get<{
-            success?: boolean;
-            data?: {
-              status?: DeepResearchStatus['status'];
-              finalAnalysis?: string;
-              json?: Record<string, unknown> | null;
-              activities?: ResearchActivity[];
-              sources?: ResearchSource[];
-              currentDepth?: number;
-              maxDepth?: number;
-              totalUrls?: number;
-              error?: string;
-            };
-          }>(`/v2/deep-research/${id}`);
+          return await requestWithVersionFallback(
+            featureVersions,
+            'deep-research',
+            async (version) => {
+              const response = await http.get<{
+                success?: boolean;
+                data?: {
+                  status?: DeepResearchStatus['status'];
+                  finalAnalysis?: string;
+                  json?: Record<string, unknown> | null;
+                  activities?: ResearchActivity[];
+                  sources?: ResearchSource[];
+                  currentDepth?: number;
+                  maxDepth?: number;
+                  totalUrls?: number;
+                  error?: string;
+                };
+              }>(`/${version}/deep-research/${id}`);
 
-          const data = response.data.data ?? {};
+              const data = response.data.data ?? {};
 
-          return {
-            data: {
-              status: data.status ?? 'processing',
-              finalAnalysis: data.finalAnalysis ?? '',
-              json: data.json ?? null,
-              activities: data.activities ?? [],
-              sources: data.sources ?? [],
-              currentDepth: data.currentDepth ?? 0,
-              maxDepth: data.maxDepth ?? 0,
-              totalUrls: data.totalUrls ?? 0,
-              error: data.error ?? null,
+              return {
+                data: {
+                  status: data.status ?? 'processing',
+                  finalAnalysis: data.finalAnalysis ?? '',
+                  json: data.json ?? null,
+                  activities: data.activities ?? [],
+                  sources: data.sources ?? [],
+                  currentDepth: data.currentDepth ?? 0,
+                  maxDepth: data.maxDepth ?? 0,
+                  totalUrls: data.totalUrls ?? 0,
+                  error: data.error ?? null,
+                  apiVersion: version,
+                },
+              };
             },
-          };
+          );
         } catch (error) {
           throw formatApiError(error, 'Failed to fetch deep research status');
         }
@@ -1008,35 +1118,40 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
     llmsTxt: {
       async generateLlmsTxt(payload) {
         try {
-          const response = await http.post<{ success: boolean; id: string }>(
-            '/v2/llmstxt',
-            payload,
-          );
+          return await requestWithVersionFallback(featureVersions, 'llmstxt', async (version) => {
+            const response = await http.post<{ success: boolean; id: string }>(
+              `/${version}/llmstxt`,
+              payload,
+            );
 
-          return {
-            data: { id: response.data.id },
-          };
+            return {
+              data: { id: response.data.id, apiVersion: version },
+            };
+          });
         } catch (error) {
           throw formatApiError(error, 'Failed to start LLMs.txt generation');
         }
       },
       async getLlmsTxtStatus(id) {
         try {
-          const response = await http.get<{
-            success?: boolean;
-            status?: LlmsTxtStatus['status'];
-            data?: { llmstxt?: string; llmsfulltxt?: string };
-          }>(`/v2/llmstxt/${id}`);
+          return await requestWithVersionFallback(featureVersions, 'llmstxt', async (version) => {
+            const response = await http.get<{
+              success?: boolean;
+              status?: LlmsTxtStatus['status'];
+              data?: { llmstxt?: string; llmsfulltxt?: string };
+            }>(`/${version}/llmstxt/${id}`);
 
-          const data = response.data.data ?? {};
+            const data = response.data.data ?? {};
 
-          return {
-            data: {
-              status: response.data.status ?? 'processing',
-              llmstxt: data.llmstxt ?? '',
-              llmsfulltxt: data.llmsfulltxt ?? '',
-            },
-          };
+            return {
+              data: {
+                status: response.data.status ?? 'processing',
+                llmstxt: data.llmstxt ?? '',
+                llmsfulltxt: data.llmsfulltxt ?? '',
+                apiVersion: version,
+              },
+            };
+          });
         } catch (error) {
           throw formatApiError(error, 'Failed to fetch LLMs.txt status');
         }

--- a/src/services/firecrawl.ts
+++ b/src/services/firecrawl.ts
@@ -272,6 +272,7 @@ export interface DeepResearchStatus {
   totalUrls: number;
   error: string | null;
   apiVersion: FirecrawlApiVersion;
+  warnings: string[];
 }
 
 /**
@@ -292,6 +293,7 @@ export interface LlmsTxtStatus {
   llmstxt: string;
   llmsfulltxt: string;
   apiVersion: FirecrawlApiVersion;
+  warnings: string[];
 }
 
 /**
@@ -1077,22 +1079,31 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
             featureVersions,
             'deep-research',
             async (version) => {
-              const response = await http.get<{
-                success?: boolean;
-                data?: {
-                  status?: DeepResearchStatus['status'];
-                  finalAnalysis?: string;
-                  json?: Record<string, unknown> | null;
-                  activities?: ResearchActivity[];
-                  sources?: ResearchSource[];
-                  currentDepth?: number;
-                  maxDepth?: number;
-                  totalUrls?: number;
-                  error?: string;
-                };
-              }>(`/${version}/deep-research/${id}`);
+              type DeepResearchFields = {
+                status?: DeepResearchStatus['status'];
+                finalAnalysis?: string;
+                json?: Record<string, unknown> | null;
+                activities?: ResearchActivity[];
+                sources?: ResearchSource[];
+                currentDepth?: number;
+                maxDepth?: number;
+                totalUrls?: number;
+                error?: string;
+              };
 
-              const data = response.data.data ?? {};
+              const response = await http.get<
+                DeepResearchFields & {
+                  success?: boolean;
+                  warnings?: string[];
+                  data?: DeepResearchFields;
+                }
+              >(`/${version}/deep-research/${id}`);
+
+              const body = response.data;
+              // v2 nests every job field under `data`. The deprecated v1
+              // endpoint returns most of them at the top level and nests only
+              // activities and sources, so read from both, nested first.
+              const data: DeepResearchFields = { ...body, ...(body.data ?? {}) };
 
               return {
                 data: {
@@ -1106,6 +1117,7 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
                   totalUrls: data.totalUrls ?? 0,
                   error: data.error ?? null,
                   apiVersion: version,
+                  warnings: body.warnings ?? [],
                 },
               };
             },
@@ -1138,6 +1150,7 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
             const response = await http.get<{
               success?: boolean;
               status?: LlmsTxtStatus['status'];
+              warnings?: string[];
               data?: { llmstxt?: string; llmsfulltxt?: string };
             }>(`/${version}/llmstxt/${id}`);
 
@@ -1149,6 +1162,7 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
                 llmstxt: data.llmstxt ?? '',
                 llmsfulltxt: data.llmsfulltxt ?? '',
                 apiVersion: version,
+                warnings: response.data.warnings ?? [],
               },
             };
           });

--- a/src/services/firecrawl.ts
+++ b/src/services/firecrawl.ts
@@ -130,12 +130,61 @@ export interface FirecrawlScrapingApi {
 /**
  * Legacy-compatible crawling client.
  */
+export interface CrawlError {
+  id?: string;
+  timestamp?: string | null;
+  url?: string;
+  error?: string;
+}
+
+/**
+ * Crawl error report returned by the errors endpoint.
+ */
+export interface CrawlErrorsReport {
+  errors: CrawlError[];
+  robotsBlocked: string[];
+}
+
+export interface ActiveCrawl {
+  id: string;
+  url?: string;
+  teamId?: string;
+  options?: Record<string, unknown>;
+}
+
 export interface FirecrawlCrawlingApi {
   crawlUrls(
     payload: Record<string, unknown>,
   ): Promise<WrappedResponse<{ id: string; url: string }>>;
   getCrawlStatus(id: string): Promise<WrappedResponse<LegacyCrawlStatusResponse>>;
   cancelCrawl(id: string): Promise<WrappedResponse<{ status: string }>>;
+  getCrawlErrors(id: string): Promise<WrappedResponse<CrawlErrorsReport>>;
+  getActiveCrawls(): Promise<WrappedResponse<{ crawls: ActiveCrawl[] }>>;
+}
+
+/**
+ * Status of a batch scrape job, mirroring the crawl status structure with the
+ * extra `creditsUsed` counter exposed by the batch endpoint.
+ */
+export interface BatchScrapeStatusResponse {
+  status: CrawlJob['status'];
+  completed: number;
+  total: number;
+  creditsUsed: number;
+  next: string | null;
+  data: Record<string, unknown>[];
+}
+
+/**
+ * Legacy-compatible batch scraping client.
+ */
+export interface FirecrawlBatchScrapingApi {
+  batchScrape(
+    payload: Record<string, unknown>,
+  ): Promise<WrappedResponse<{ id: string; url: string }>>;
+  getBatchScrapeStatus(id: string): Promise<WrappedResponse<BatchScrapeStatusResponse>>;
+  cancelBatchScrape(id: string): Promise<WrappedResponse<{ message: string }>>;
+  getBatchScrapeErrors(id: string): Promise<WrappedResponse<CrawlErrorsReport>>;
 }
 
 /**
@@ -143,6 +192,7 @@ export interface FirecrawlCrawlingApi {
  */
 export interface FirecrawlExtractionApi {
   extractData(payload: Record<string, unknown>): Promise<WrappedResponse<FirecrawlExtractResponse>>;
+  getExtractStatus(id: string): Promise<WrappedResponse<FirecrawlExtractResponse>>;
 }
 
 /**
@@ -160,12 +210,105 @@ export interface FirecrawlSearchApi {
 }
 
 /**
+ * Team credit usage information returned by Firecrawl.
+ *
+ * Only `remainingCredits` is guaranteed by the API contract; the optional
+ * fields are surfaced when the Firecrawl plan exposes them.
+ */
+export interface CreditUsage {
+  remainingCredits: number | null;
+  planCredits?: number | null;
+  billingPeriodStart?: string | null;
+  billingPeriodEnd?: string | null;
+}
+
+/**
+ * Team token usage information returned by Firecrawl (Extract feature).
+ */
+export interface TokenUsage {
+  remainingTokens: number | null;
+}
+
+/**
+ * Legacy-compatible billing client.
+ */
+export interface FirecrawlBillingApi {
+  getCreditUsage(): Promise<WrappedResponse<CreditUsage>>;
+  getTokenUsage(): Promise<WrappedResponse<TokenUsage>>;
+}
+
+/**
+ * A single activity entry emitted while a deep research job progresses.
+ */
+export interface ResearchActivity {
+  type?: string;
+  status?: string;
+  message?: string;
+  timestamp?: string;
+  depth?: number;
+}
+
+/**
+ * A source discovered and analyzed during a deep research job.
+ */
+export interface ResearchSource {
+  url?: string;
+  title?: string;
+  description?: string;
+  favicon?: string;
+}
+
+/**
+ * Status and results of a deep research job.
+ */
+export interface DeepResearchStatus {
+  status: 'processing' | 'completed' | 'failed';
+  finalAnalysis: string;
+  json: Record<string, unknown> | null;
+  activities: ResearchActivity[];
+  sources: ResearchSource[];
+  currentDepth: number;
+  maxDepth: number;
+  totalUrls: number;
+  error: string | null;
+}
+
+/**
+ * Legacy-compatible deep research client.
+ */
+export interface FirecrawlResearchApi {
+  startDeepResearch(payload: Record<string, unknown>): Promise<WrappedResponse<{ id: string }>>;
+  getDeepResearchStatus(id: string): Promise<WrappedResponse<DeepResearchStatus>>;
+}
+
+/**
+ * Status and results of an LLMs.txt generation job.
+ */
+export interface LlmsTxtStatus {
+  status: 'processing' | 'completed' | 'failed';
+  llmstxt: string;
+  llmsfulltxt: string;
+}
+
+/**
+ * Legacy-compatible LLMs.txt generation client.
+ */
+export interface FirecrawlLlmsTxtApi {
+  generateLlmsTxt(payload: Record<string, unknown>): Promise<WrappedResponse<{ id: string }>>;
+  getLlmsTxtStatus(id: string): Promise<WrappedResponse<LlmsTxtStatus>>;
+}
+
+/**
  * Collection of all Firecrawl adapters exposed to Vue.
  */
 export interface FirecrawlApiClients {
+  billing: FirecrawlBillingApi;
+  batchScraping: FirecrawlBatchScrapingApi;
   crawling: FirecrawlCrawlingApi;
   extraction: FirecrawlExtractionApi;
+  llmsTxt: FirecrawlLlmsTxtApi;
   mapping: FirecrawlMappingApi;
+  research: FirecrawlResearchApi;
   scraping: FirecrawlScrapingApi;
   search: FirecrawlSearchApi;
 }
@@ -542,6 +685,54 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
   const http = createHttpClient(apiKey, baseUrl);
 
   return {
+    billing: {
+      async getCreditUsage() {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            data?: {
+              remaining_credits?: number;
+              plan_credits?: number;
+              billing_period_start?: string | null;
+              billing_period_end?: string | null;
+            };
+          }>('/v2/team/credit-usage');
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              remainingCredits:
+                typeof data.remaining_credits === 'number' ? data.remaining_credits : null,
+              planCredits: typeof data.plan_credits === 'number' ? data.plan_credits : null,
+              billingPeriodStart: data.billing_period_start ?? null,
+              billingPeriodEnd: data.billing_period_end ?? null,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch credit usage');
+        }
+      },
+      async getTokenUsage() {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            data?: { remaining_tokens?: number };
+          }>('/v2/team/token-usage');
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              remainingTokens:
+                typeof data.remaining_tokens === 'number' ? data.remaining_tokens : null,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch token usage');
+        }
+      },
+    },
     scraping: {
       async scrapeAndExtractFromUrl(payload) {
         try {
@@ -615,12 +806,125 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
           );
 
           return {
-            data: {
-              status: response.data.status ?? 'cancelled',
-            },
+            data: { status: response.data.status ?? 'cancelled' },
           };
         } catch (error) {
           throw formatApiError(error, 'Failed to cancel crawl');
+        }
+      },
+      async getCrawlErrors(id) {
+        try {
+          const response = await http.get<{
+            errors?: CrawlError[];
+            robotsBlocked?: string[];
+          }>(`/v2/crawl/${id}/errors`);
+
+          return {
+            data: {
+              errors: response.data.errors ?? [],
+              robotsBlocked: response.data.robotsBlocked ?? [],
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch crawl errors');
+        }
+      },
+      async getActiveCrawls() {
+        try {
+          const response = await http.get<{ success?: boolean; crawls?: ActiveCrawl[] }>(
+            '/v2/crawl/active',
+          );
+
+          return {
+            data: { crawls: response.data.crawls ?? [] },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch active crawls');
+        }
+      },
+    },
+    batchScraping: {
+      async batchScrape(payload) {
+        try {
+          const urls = Array.isArray(payload.urls)
+            ? (payload.urls as unknown[]).filter((url): url is string => typeof url === 'string')
+            : [];
+          // Reuse the single-scrape option mapping to keep batch options in sync.
+          const { options } = toScrapeRequest({ url: '', ...payload });
+          const response = await http.post<{ success: boolean; id: string; url: string }>(
+            '/v2/batch/scrape',
+            {
+              urls,
+              ...options,
+              ...(typeof payload.webhook === 'object' && payload.webhook !== null
+                ? { webhook: payload.webhook }
+                : {}),
+            },
+          );
+
+          return {
+            data: {
+              id: response.data.id,
+              url: response.data.url,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Batch scrape request failed');
+        }
+      },
+      async getBatchScrapeStatus(id) {
+        try {
+          const response = await http.get<{
+            status?: CrawlJob['status'];
+            completed?: number;
+            total?: number;
+            creditsUsed?: number;
+            next?: string | null;
+            data?: Document[];
+          }>(`/v2/batch/scrape/${id}`);
+
+          return {
+            data: {
+              status: response.data.status ?? 'scraping',
+              completed: response.data.completed ?? 0,
+              total: response.data.total ?? 0,
+              creditsUsed: response.data.creditsUsed ?? 0,
+              next: response.data.next ?? null,
+              data: (response.data.data ?? []).map(toLegacyDocument),
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch batch scrape status');
+        }
+      },
+      async cancelBatchScrape(id) {
+        try {
+          const response = await http.delete<{ success?: boolean; message?: string }>(
+            `/v2/batch/scrape/${id}`,
+          );
+
+          return {
+            data: { message: response.data.message ?? 'Batch scrape job cancelled.' },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to cancel batch scrape');
+        }
+      },
+      async getBatchScrapeErrors(id) {
+        try {
+          const response = await http.get<{
+            errors?: CrawlError[];
+            robotsBlocked?: string[];
+          }>(`/v2/batch/scrape/${id}/errors`);
+
+          return {
+            data: {
+              errors: response.data.errors ?? [],
+              robotsBlocked: response.data.robotsBlocked ?? [],
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch batch scrape errors');
         }
       },
     },
@@ -635,6 +939,106 @@ export function createFirecrawlApiClients(apiKey: string, baseUrl: string): Fire
           };
         } catch (error) {
           throw formatApiError(error, 'Extract request failed');
+        }
+      },
+      async getExtractStatus(id) {
+        try {
+          const response = await http.get<FirecrawlExtractResponse>(`/v2/extract/${id}`);
+
+          return {
+            data: response.data,
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch extract status');
+        }
+      },
+    },
+    research: {
+      async startDeepResearch(payload) {
+        try {
+          const response = await http.post<{ success: boolean; id: string }>(
+            '/v2/deep-research',
+            payload,
+          );
+
+          return {
+            data: { id: response.data.id },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to start deep research');
+        }
+      },
+      async getDeepResearchStatus(id) {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            data?: {
+              status?: DeepResearchStatus['status'];
+              finalAnalysis?: string;
+              json?: Record<string, unknown> | null;
+              activities?: ResearchActivity[];
+              sources?: ResearchSource[];
+              currentDepth?: number;
+              maxDepth?: number;
+              totalUrls?: number;
+              error?: string;
+            };
+          }>(`/v2/deep-research/${id}`);
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              status: data.status ?? 'processing',
+              finalAnalysis: data.finalAnalysis ?? '',
+              json: data.json ?? null,
+              activities: data.activities ?? [],
+              sources: data.sources ?? [],
+              currentDepth: data.currentDepth ?? 0,
+              maxDepth: data.maxDepth ?? 0,
+              totalUrls: data.totalUrls ?? 0,
+              error: data.error ?? null,
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch deep research status');
+        }
+      },
+    },
+    llmsTxt: {
+      async generateLlmsTxt(payload) {
+        try {
+          const response = await http.post<{ success: boolean; id: string }>(
+            '/v2/llmstxt',
+            payload,
+          );
+
+          return {
+            data: { id: response.data.id },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to start LLMs.txt generation');
+        }
+      },
+      async getLlmsTxtStatus(id) {
+        try {
+          const response = await http.get<{
+            success?: boolean;
+            status?: LlmsTxtStatus['status'];
+            data?: { llmstxt?: string; llmsfulltxt?: string };
+          }>(`/v2/llmstxt/${id}`);
+
+          const data = response.data.data ?? {};
+
+          return {
+            data: {
+              status: response.data.status ?? 'processing',
+              llmstxt: data.llmstxt ?? '',
+              llmsfulltxt: data.llmsfulltxt ?? '',
+            },
+          };
+        } catch (error) {
+          throw formatApiError(error, 'Failed to fetch LLMs.txt status');
         }
       },
     },

--- a/src/views/BatchScrapeView.vue
+++ b/src/views/BatchScrapeView.vue
@@ -1,0 +1,503 @@
+<template>
+  <div class="page-container batch-scrape-view">
+    <h2>Batch Scrape</h2>
+    <p class="intro">Scrape multiple URLs in a single job and track progress.</p>
+
+    <form class="batch-form" @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="urls">URLs (one per line):</label>
+        <textarea
+          id="urls"
+          v-model="urlsInput"
+          rows="6"
+          placeholder="https://example.com&#10;https://example.org/page"
+          required
+        ></textarea>
+        <small>Each non-empty line is treated as a URL to scrape.</small>
+      </div>
+
+      <div class="form-group">
+        <label for="formats">Output Formats:</label>
+        <select id="formats" v-model="selectedFormats" multiple>
+          <option value="markdown">Markdown</option>
+          <option value="html">HTML</option>
+          <option value="rawHtml">Raw HTML</option>
+          <option value="links">Links</option>
+          <option value="summary">Summary</option>
+          <option value="screenshot">Screenshot (Viewport)</option>
+          <option value="screenshot@fullPage">Screenshot (Full Page)</option>
+        </select>
+        <small>Select one or more formats.</small>
+      </div>
+
+      <label class="checkbox-label">
+        <input type="checkbox" v-model="onlyMainContent" />
+        Only Main Content (exclude headers, footers, etc.)
+      </label>
+
+      <button type="submit" class="primary-button" :disabled="loading">
+        {{ loading ? 'Submitting…' : 'Start Batch Scrape' }}
+      </button>
+    </form>
+
+    <div v-if="error" class="error">{{ error }}</div>
+
+    <!-- Progress while the batch job is running -->
+    <div v-if="jobId" class="status-section">
+      <h3>Batch Status</h3>
+      <p>Job ID: {{ jobId }}</p>
+      <p>Status: {{ status }}</p>
+      <div class="progress-container">
+        <div class="progress-bar" :style="{ width: progress + '%' }"></div>
+      </div>
+      <p>{{ completed }} / {{ total }} pages scraped ({{ progress }}%)</p>
+      <p v-if="creditsUsed">Credits used: {{ creditsUsed }}</p>
+      <div class="status-actions">
+        <!-- Cancel button: visible only while the job is actively running -->
+        <button
+          v-if="isJobRunning"
+          class="cancel-button"
+          type="button"
+          :disabled="cancelling"
+          @click="cancelJob"
+        >
+          {{ cancelling ? 'Cancelling…' : 'Cancel' }}
+        </button>
+        <!-- Check Errors button: visible whenever a job ID exists -->
+        <button class="download-button" type="button" @click="loadErrors">Check Errors</button>
+      </div>
+    </div>
+
+    <!-- Section listing scrape errors for the current batch job -->
+    <div v-if="errorsLoaded" class="batch-errors-section">
+      <h3>Batch Errors</h3>
+      <p v-if="batchErrors.length === 0 && batchRobotsBlocked.length === 0">No errors reported.</p>
+      <ul v-if="batchErrors.length > 0" class="errors-list">
+        <li v-for="(err, index) in batchErrors" :key="err.id || index">
+          <strong>{{ err.url || 'Unknown URL' }}</strong> — {{ err.error || 'Unknown error' }}
+          <em v-if="err.timestamp"> ({{ new Date(err.timestamp).toLocaleString() }})</em>
+        </li>
+      </ul>
+      <div v-if="batchRobotsBlocked.length > 0">
+        <h4>Blocked by robots.txt</h4>
+        <ul class="errors-list">
+          <li v-for="(url, index) in batchRobotsBlocked" :key="index">{{ url }}</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Results once the batch is completed -->
+    <div v-if="results.length" class="results">
+      <h3>Results ({{ results.length }})</h3>
+      <ul class="result-list">
+        <li v-for="(doc, index) in results" :key="index">
+          {{ docTitle(doc) }}
+        </li>
+      </ul>
+      <button class="download-button" type="button" @click="downloadJson">Download JSON</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, inject, onUnmounted } from 'vue';
+import type { CrawlError, FirecrawlBatchScrapingApi } from '@/services/firecrawl';
+
+/**
+ * BatchScrapeView Component
+ *
+ * Lets the user submit several URLs as a single batch scrape job, polls the job
+ * status until completion, and renders the scraped documents with a JSON export.
+ * Also supports cancelling an in-progress job and fetching the error report.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * @type {{ batchScraping?: FirecrawlBatchScrapingApi } | undefined}
+ */
+const api = inject('api') as { batchScraping?: FirecrawlBatchScrapingApi } | undefined;
+if (!api?.batchScraping) {
+  throw new Error(
+    'Batch scraping API is not available. Ensure the API plugin is correctly configured.',
+  );
+}
+
+/** Raw multiline textarea content holding one URL per line. */
+const urlsInput = ref('');
+/** Selected output formats for the scrape. */
+const selectedFormats = ref<string[]>(['markdown']);
+/** Whether to restrict extraction to the main content of each page. */
+const onlyMainContent = ref(true);
+
+/** Whether a submission request is currently in flight. */
+const loading = ref(false);
+/** User-facing error message. */
+const error = ref('');
+
+/** Identifier of the running batch job, or null when idle. */
+const jobId = ref<string | null>(null);
+/** Current job status label. */
+const status = ref('');
+/** Number of pages scraped so far. */
+const completed = ref(0);
+/** Total number of pages in the job. */
+const total = ref(0);
+/** Completion percentage derived from completed/total. */
+const progress = ref(0);
+/** Number of credits consumed by the job. */
+const creditsUsed = ref(0);
+/** Scraped documents returned once the job completes. */
+const results = ref<Record<string, unknown>[]>([]);
+
+/** Whether a cancel request is currently in flight. */
+const cancelling = ref(false);
+
+/** Errors reported for the current batch job. */
+const batchErrors = ref<CrawlError[]>([]);
+/** URLs blocked by robots.txt for the current batch job. */
+const batchRobotsBlocked = ref<string[]>([]);
+/** Whether the error report has been fetched at least once for the current job. */
+const errorsLoaded = ref(false);
+
+/** Polling interval handle. */
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * True while the job is actively scraping or processing (i.e. not yet in a
+ * terminal state). Used to control the visibility of the Cancel button.
+ */
+const isJobRunning = computed(
+  () =>
+    jobId.value !== null &&
+    status.value !== 'completed' &&
+    status.value !== 'failed' &&
+    status.value !== 'cancelled',
+);
+
+/**
+ * Derive a human-readable label from a scraped document.
+ *
+ * @param doc - The scraped document record.
+ * @returns The document title, source URL, or a fallback string.
+ */
+function docTitle(doc: Record<string, unknown>): string {
+  const metadata = (doc.metadata as Record<string, unknown> | undefined) ?? {};
+  return (
+    (metadata.title as string | undefined) ||
+    (metadata.sourceURL as string | undefined) ||
+    (doc.url as string | undefined) ||
+    'Untitled document'
+  );
+}
+
+/**
+ * Stop the status polling loop, if any is active.
+ */
+function stopPolling(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Poll the batch scrape status endpoint until the job completes or fails.
+ *
+ * @param id - The batch job identifier.
+ */
+function pollStatus(id: string): void {
+  stopPolling();
+  intervalId = setInterval(async () => {
+    try {
+      const response = await api.batchScraping!.getBatchScrapeStatus(id);
+      const data = response.data;
+      status.value = data.status;
+      completed.value = data.completed;
+      total.value = data.total;
+      creditsUsed.value = data.creditsUsed;
+      progress.value = data.total > 0 ? Math.round((data.completed / data.total) * 100) : 0;
+
+      if (data.status === 'completed' || data.status === 'failed') {
+        results.value = data.data;
+        stopPolling();
+      }
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch batch status.';
+      status.value = 'failed';
+      stopPolling();
+    }
+  }, 3000);
+}
+
+/**
+ * Submit the batch scrape job from the current form inputs and start polling.
+ *
+ * @returns {Promise<void>} Resolves once the job has been submitted.
+ */
+async function handleSubmit(): Promise<void> {
+  const urls = urlsInput.value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (urls.length === 0) {
+    error.value = 'Please enter at least one URL.';
+    return;
+  }
+  if (selectedFormats.value.length === 0) {
+    error.value = 'Please select at least one output format.';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  results.value = [];
+  jobId.value = null;
+  errorsLoaded.value = false;
+  batchErrors.value = [];
+  batchRobotsBlocked.value = [];
+  try {
+    const response = await api.batchScraping!.batchScrape({
+      urls,
+      formats: selectedFormats.value,
+      onlyMainContent: onlyMainContent.value,
+    });
+    jobId.value = response.data.id;
+    status.value = 'scraping';
+    pollStatus(response.data.id);
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to start batch scrape.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+/**
+ * Cancel the currently running batch scrape job.
+ *
+ * Calls the cancel endpoint, stops polling, and sets the status to 'cancelled'.
+ * Any API error is surfaced through the existing error ref.
+ *
+ * @returns {Promise<void>} Resolves once the cancel request completes.
+ */
+async function cancelJob(): Promise<void> {
+  if (!jobId.value) {
+    return;
+  }
+  cancelling.value = true;
+  error.value = '';
+  try {
+    await api.batchScraping!.cancelBatchScrape(jobId.value);
+    stopPolling();
+    status.value = 'cancelled';
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to cancel batch scrape job.';
+  } finally {
+    cancelling.value = false;
+  }
+}
+
+/**
+ * Fetch the error report for the current batch job and populate the errors section.
+ *
+ * Both `batchErrors` and `batchRobotsBlocked` are updated; `errorsLoaded` is
+ * set to true so the errors section becomes visible. Any API error is surfaced
+ * through the existing error ref.
+ *
+ * @returns {Promise<void>} Resolves once the error report has been fetched.
+ */
+async function loadErrors(): Promise<void> {
+  if (!jobId.value) {
+    return;
+  }
+  error.value = '';
+  try {
+    const response = await api.batchScraping!.getBatchScrapeErrors(jobId.value);
+    batchErrors.value = response.data.errors;
+    batchRobotsBlocked.value = response.data.robotsBlocked;
+    errorsLoaded.value = true;
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to fetch batch scrape errors.';
+  }
+}
+
+/**
+ * Download the scraped documents as a JSON file.
+ */
+function downloadJson(): void {
+  const blob = new Blob([JSON.stringify(results.value, null, 2)], { type: 'application/json' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = `batch-scrape-${jobId.value ?? 'results'}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+// Clean up the polling loop when the component is destroyed.
+onUnmounted(stopPolling);
+</script>
+
+<style scoped>
+.batch-scrape-view {
+  max-width: 700px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.batch-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+textarea,
+select {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
+}
+
+.form-group small {
+  font-size: 0.8em;
+  color: var(--color-text);
+  opacity: 0.7;
+  margin-top: 3px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: normal;
+}
+
+.primary-button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-section {
+  margin-top: 1.5rem;
+}
+
+.status-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.cancel-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #dc3545;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cancel-button:hover:not(:disabled) {
+  background-color: #b02a37;
+}
+
+.cancel-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.progress-container {
+  width: 100%;
+  background-color: var(--color-background-mute);
+  border-radius: 5px;
+  margin: 10px 0;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 20px;
+  background-color: #4caf50;
+  transition: width 0.5s ease;
+}
+
+.batch-errors-section {
+  margin: 1.5rem 0;
+  padding: 15px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-background-soft);
+}
+
+.errors-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  word-break: break-all;
+}
+
+.results {
+  margin-top: 1.5rem;
+}
+
+.result-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  word-break: break-all;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/views/BillingView.vue
+++ b/src/views/BillingView.vue
@@ -1,0 +1,229 @@
+<template>
+  <div class="page-container billing-view">
+    <h2>Billing &amp; Credits</h2>
+    <p class="intro">Check the remaining Firecrawl credits available for your team.</p>
+
+    <button type="button" class="primary-button" :disabled="loading" @click="fetchUsage">
+      {{ loading ? 'Loading…' : 'Refresh credit usage' }}
+    </button>
+
+    <div v-if="error" class="error">{{ error }}</div>
+    <div v-else-if="loading" class="status">Loading…</div>
+
+    <div v-else-if="usage" class="results">
+      <div class="credit-cards">
+        <div class="credit-card highlight">
+          <span class="credit-label">Remaining credits</span>
+          <span class="credit-value">{{ formatNumber(usage.remainingCredits) }}</span>
+        </div>
+        <div v-if="usage.planCredits != null" class="credit-card">
+          <span class="credit-label">Plan credits</span>
+          <span class="credit-value">{{ formatNumber(usage.planCredits) }}</span>
+        </div>
+        <div v-if="tokenUsage" class="credit-card">
+          <span class="credit-label">Remaining tokens (Extract)</span>
+          <span class="credit-value">{{ formatNumber(tokenUsage.remainingTokens) }}</span>
+        </div>
+      </div>
+
+      <div v-if="usage.billingPeriodStart || usage.billingPeriodEnd" class="billing-period">
+        <h3>Billing period</h3>
+        <p>
+          <span v-if="usage.billingPeriodStart">{{ usage.billingPeriodStart }}</span>
+          <span v-if="usage.billingPeriodStart && usage.billingPeriodEnd"> → </span>
+          <span v-if="usage.billingPeriodEnd">{{ usage.billingPeriodEnd }}</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, inject, onMounted } from 'vue';
+import type { CreditUsage, TokenUsage, FirecrawlBillingApi } from '@/services/firecrawl';
+
+/**
+ * BillingView Component
+ *
+ * Displays the team's Firecrawl credit usage. It fetches the remaining credits
+ * (and, when available, plan credits and the current billing period) from the
+ * billing API adapter exposed by the API plugin.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * This instance is expected to contain a `billing` property for credit queries.
+ * @type {{ billing?: FirecrawlBillingApi } | undefined}
+ */
+const api = inject('api') as { billing?: FirecrawlBillingApi } | undefined;
+if (!api?.billing) {
+  throw new Error(
+    'Billing API is not available. Ensure the API plugin is correctly configured and provides the billing service.',
+  );
+}
+
+/**
+ * Reactive credit usage data returned by the API, or `null` before the first load.
+ * @type {Ref<CreditUsage | null>}
+ */
+const usage = ref<CreditUsage | null>(null);
+
+/**
+ * Reactive token usage data (Extract feature), or `null` before the first load.
+ * @type {Ref<TokenUsage | null>}
+ */
+const tokenUsage = ref<TokenUsage | null>(null);
+
+/**
+ * Reactive flag indicating whether a request is currently in progress.
+ * @type {Ref<boolean>}
+ */
+const loading = ref(false);
+
+/**
+ * Reactive error message displayed when a request fails.
+ * @type {Ref<string>}
+ */
+const error = ref('');
+
+/**
+ * Format a numeric credit value with thousands separators for readability.
+ *
+ * @param value - The numeric value to format, or `null` when unavailable.
+ * @returns A localized string, or a dash when the value is missing.
+ */
+function formatNumber(value: number | null | undefined): string {
+  return typeof value === 'number' ? value.toLocaleString() : '—';
+}
+
+/**
+ * Fetch the current credit usage from the billing API and update local state.
+ * Manages the loading and error states around the request.
+ *
+ * @returns {Promise<void>} A promise that resolves once the request completes.
+ */
+async function fetchUsage(): Promise<void> {
+  loading.value = true;
+  error.value = '';
+  try {
+    // Fetch credit and token usage together; both belong to the Billing tag.
+    const [creditResponse, tokenResponse] = await Promise.all([
+      api.billing!.getCreditUsage(),
+      api.billing!.getTokenUsage(),
+    ]);
+    usage.value = creditResponse.data;
+    tokenUsage.value = tokenResponse.data;
+  } catch (err: unknown) {
+    error.value =
+      err instanceof Error ? err.message : 'Failed to fetch usage information. Please try again.';
+    usage.value = null;
+    tokenUsage.value = null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Automatically load credit usage when the view is mounted.
+onMounted(fetchUsage);
+</script>
+
+<style scoped>
+/* Main container for the BillingView component. */
+.billing-view {
+  max-width: 600px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+/* Introductory description text. */
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+/* Primary action button. */
+.primary-button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Results section wrapping the credit cards. */
+.results {
+  margin-top: 1.5rem;
+}
+
+/* Layout for the credit summary cards. */
+.credit-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+/* Individual credit card. */
+.credit-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  min-width: 160px;
+  background: var(--color-background-soft);
+}
+
+/* Emphasized card for the primary metric. */
+.credit-card.highlight {
+  border-color: #007acc;
+  background: var(--color-background-mute);
+}
+
+/* Small label above each credit value. */
+.credit-label {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+/* Prominent numeric credit value. */
+.credit-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #007acc;
+}
+
+/* Billing period block. */
+.billing-period {
+  margin-top: 1.5rem;
+}
+
+.billing-period h3 {
+  margin-bottom: 0.25rem;
+}
+
+/* Error message styling. */
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+
+/* Status (loading) message styling. */
+.status {
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/views/CrawlView.vue
+++ b/src/views/CrawlView.vue
@@ -385,9 +385,14 @@
           </div>
           <p>{{ progress }}% Completed</p>
           <p>{{ pagesCompleted }} / {{ totalPages }} pages processed</p>
-          <button class="primary-button" type="button" @click="cancelCurrentCrawl">
-            Cancel Crawl
-          </button>
+          <div class="crawl-status-actions">
+            <button class="primary-button" type="button" @click="cancelCurrentCrawl">
+              Cancel Crawl
+            </button>
+            <button class="primary-button" type="button" @click="loadCrawlErrors">
+              Check Errors
+            </button>
+          </div>
         </div>
 
         <!-- Completed crawl summary (when not actively crawling) -->
@@ -399,6 +404,36 @@
           </div>
           <p>{{ progress }}% Completed</p>
           <p>{{ pagesCompleted }} / {{ totalPages }} pages processed</p>
+          <div class="crawl-status-actions">
+            <button class="primary-button" type="button" @click="loadCrawlErrors">
+              Check Errors
+            </button>
+          </div>
+        </div>
+
+        <!-- Per-URL error report, fetched on demand via "Check Errors". Only
+             rendered once a report has actually been retrieved, so an empty
+             list is distinguishable from "never asked". -->
+        <div v-if="crawlErrorsLoaded" class="crawl-errors-section">
+          <h3>Crawl Errors</h3>
+          <p v-if="crawlErrors.length === 0 && robotsBlocked.length === 0">
+            No errors reported for this crawl.
+          </p>
+          <ul v-if="crawlErrors.length > 0" class="errors-list">
+            <li v-for="(crawlError, index) in crawlErrors" :key="crawlError.id || index">
+              <strong>{{ crawlError.url || 'Unknown URL' }}</strong>
+              <span class="error-detail">{{ crawlError.error || 'Unknown error' }}</span>
+              <em v-if="crawlError.timestamp" class="error-timestamp">
+                {{ new Date(crawlError.timestamp).toLocaleString() }}
+              </em>
+            </li>
+          </ul>
+          <template v-if="robotsBlocked.length > 0">
+            <h4>Blocked by robots.txt</h4>
+            <ul class="errors-list">
+              <li v-for="(blockedUrl, index) in robotsBlocked" :key="index">{{ blockedUrl }}</li>
+            </ul>
+          </template>
         </div>
 
         <!-- Download options after crawl completion -->
@@ -485,6 +520,29 @@
           </button>
         </div>
 
+        <!-- Crawls running server-side right now. Unlike the history below,
+             this list comes from the API, so it also covers jobs started from
+             another browser or another client. -->
+        <div class="active-crawls-section">
+          <div class="section-header">
+            <h2>Active Crawls</h2>
+            <button class="history-button" type="button" @click="loadActiveCrawls">Refresh</button>
+          </div>
+          <div v-if="activeCrawlsError" class="error-message">{{ activeCrawlsError }}</div>
+          <ul v-else-if="activeCrawls.length > 0" class="history-list">
+            <li v-for="crawl in activeCrawls" :key="crawl.id" class="history-item">
+              <span class="history-info">
+                <strong>{{ crawl.url || 'Unknown URL' }}</strong>
+                <span class="history-meta">ID: {{ crawl.id }}</span>
+              </span>
+              <button class="history-button" type="button" @click.prevent="selectCrawl(crawl.id)">
+                View
+              </button>
+            </li>
+          </ul>
+          <p v-else>No active crawls.</p>
+        </div>
+
         <!-- Crawl history -->
         <div class="crawl-history-section">
           <h2>Crawl History</h2>
@@ -531,6 +589,8 @@ import { useRouter, useRoute } from 'vue-router';
 import PlaygroundLayout from '../components/playground/PlaygroundLayout.vue';
 import CodeBlock from '../components/playground/CodeBlock.vue';
 import {
+  type ActiveCrawl,
+  type CrawlError,
   type FirecrawlCrawlingApi,
   type FirecrawlExtractionApi,
   type FirecrawlMappingApi,
@@ -891,6 +951,18 @@ export default defineComponent({
     // State for selected crawl history item
     const selectedCrawlId = ref<string | null>(null);
     const simulatedFiles = ref<string[]>([]);
+
+    // Error report for the current crawl. `crawlErrorsLoaded` gates the report
+    // section so an empty report reads as "no errors" rather than "not fetched".
+    const crawlErrors = ref<CrawlError[]>([]);
+    const robotsBlocked = ref<string[]>([]);
+    const crawlErrorsLoaded = ref(false);
+
+    // Crawls currently running server-side, plus its own error slot: this list
+    // is refreshed independently of the request form, so a failure here must
+    // not overwrite the submission error shown in the layout status bar.
+    const activeCrawls = ref<ActiveCrawl[]>([]);
+    const activeCrawlsError = ref('');
 
     // LocalStorage key for crawl history
     const HISTORY_STORAGE_KEY = 'crawlHistory';
@@ -1479,6 +1551,10 @@ export default defineComponent({
         result.value = null;
         currentCrawlId.value = null;
         durationMs.value = null;
+        // Drop the previous job's error report so it cannot be read as this one's.
+        crawlErrors.value = [];
+        robotsBlocked.value = [];
+        crawlErrorsLoaded.value = false;
 
         // Call the crawling API to submit the crawl job
         const startedAt = performance.now();
@@ -1547,6 +1623,57 @@ export default defineComponent({
         currentCrawlId.value = null;
       } catch (err: any) {
         error.value = `Failed to cancel crawl: ${err.message || 'Unknown error'}`;
+      }
+    };
+
+    /**
+     * Fetch the per-URL error report for the crawl currently in focus.
+     *
+     * The job identifier is resolved in order of specificity: the running job,
+     * then the last submitted job, then the history entry the user expanded.
+     * A failure is surfaced in the layout error banner, since the user
+     * explicitly asked for this report.
+     *
+     * @returns {Promise<void>} Resolves once the report has been fetched or
+     * the failure has been reported.
+     */
+    const loadCrawlErrors = async (): Promise<void> => {
+      const jobId = currentCrawlId.value || result.value?.id || selectedCrawlId.value;
+      if (!jobId) {
+        error.value = 'No crawl job available to fetch errors.';
+        return;
+      }
+      try {
+        error.value = '';
+        const response = await api.crawling.getCrawlErrors(jobId);
+        crawlErrors.value = response.data.errors;
+        robotsBlocked.value = response.data.robotsBlocked;
+        crawlErrorsLoaded.value = true;
+      } catch (err: any) {
+        console.error(`Failed to fetch crawl errors for job ID ${jobId}:`, err);
+        error.value = `Failed to fetch crawl errors: ${err.message || 'Unknown error'}`;
+      }
+    };
+
+    /**
+     * Fetch the list of crawl jobs currently running on the API side.
+     *
+     * Failures land in `activeCrawlsError` and are rendered inside the Active
+     * Crawls section rather than in the layout error banner, so a background
+     * refresh cannot mask an error coming from the crawl form.
+     *
+     * @returns {Promise<void>} Resolves once the list has been refreshed or the
+     * failure has been recorded.
+     */
+    const loadActiveCrawls = async (): Promise<void> => {
+      activeCrawlsError.value = '';
+      try {
+        const response = await api.crawling.getActiveCrawls();
+        activeCrawls.value = response.data.crawls;
+      } catch (err: any) {
+        console.error('Failed to fetch active crawls:', err);
+        activeCrawls.value = [];
+        activeCrawlsError.value = `Failed to fetch active crawls: ${err.message || 'Unknown error'}`;
       }
     };
 
@@ -1695,7 +1822,12 @@ export default defineComponent({
           console.error('Failed to parse crawl history from LocalStorage:', e);
         }
       }
-      await Promise.all(crawlHistory.value.map((c) => checkHistoryStatus(c)));
+      await Promise.all([
+        ...crawlHistory.value.map((c) => checkHistoryStatus(c)),
+        // Seed the Active Crawls list so the History tab is meaningful before
+        // the user hits Refresh; failures stay inside that section.
+        loadActiveCrawls(),
+      ]);
     });
 
     // Cleanup polling interval when the component unmounts
@@ -1747,6 +1879,13 @@ export default defineComponent({
       statusType,
       handleSubmit,
       cancelCurrentCrawl,
+      loadCrawlErrors,
+      crawlErrors,
+      robotsBlocked,
+      crawlErrorsLoaded,
+      activeCrawls,
+      activeCrawlsError,
+      loadActiveCrawls,
       isCrawlerOptionsCollapsed,
       isScrapeOptionsCollapsed,
       isWebhookOptionsCollapsed,
@@ -1946,6 +2085,88 @@ export default defineComponent({
   gap: 0.5rem;
   flex-wrap: wrap;
   align-items: center;
+}
+
+/* Action row under the status readout (cancel / check errors). */
+.crawl-status-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+/* ---------------------------------------------------------------------------
+ * Crawl error report: glass card tinted with the danger hue so a failing
+ * crawl reads apart from the neutral status blocks above it.
+ * --------------------------------------------------------------------------- */
+.crawl-errors-section {
+  margin-top: 1.25rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--hue-danger);
+  border-left: 3px solid var(--hue-danger);
+  border-radius: var(--radius-sm);
+  background: var(--glass-fill);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+.crawl-errors-section h4 {
+  font-size: 0.9rem;
+  margin: 1rem 0 0.4rem;
+}
+
+.errors-list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 1.4rem;
+  font-size: 0.88rem;
+  color: var(--color-text-soft);
+}
+
+.errors-list li {
+  margin-bottom: 0.35rem;
+  word-break: break-word;
+}
+
+/* Message and timestamp sit on their own lines so no separator glyph is
+   needed between them on narrow panes. */
+.error-detail {
+  display: block;
+  color: var(--color-text);
+}
+
+.error-timestamp {
+  display: block;
+  font-size: 0.85em;
+  color: var(--color-text-mute);
+}
+
+/* ---------------------------------------------------------------------------
+ * Active crawls: same frosted rows as the history list, with a header row
+ * carrying the manual refresh action.
+ * --------------------------------------------------------------------------- */
+.active-crawls-section {
+  margin-bottom: 1.5rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.section-header h2 {
+  margin: 0;
+}
+
+/* Job identifier shown under the URL of an active crawl. */
+.history-meta {
+  margin-left: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--color-text-mute);
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/views/ExtractView.vue
+++ b/src/views/ExtractView.vue
@@ -236,6 +236,26 @@
           {{ loading ? 'Running…' : 'Extract' }}
         </button>
       </form>
+
+      <!-- Resume: /v2/extract jobs are addressable by id, so a result produced
+           in an earlier session can be pulled back without re-running (and
+           re-paying for) the extraction. Kept outside the form so pressing
+           Enter in the field does not submit a new extraction. -->
+      <div class="form-group resume-group">
+        <label for="resume-id-input">Resume by Job ID</label>
+        <small class="hint">Fetch the result of an extract job submitted earlier.</small>
+        <div class="resume-row">
+          <input id="resume-id-input" v-model="resumeId" type="text" placeholder="Extract job ID" />
+          <button
+            type="button"
+            class="action-button"
+            :disabled="loading || !resumeId.trim()"
+            @click="resumeExtraction"
+          >
+            Fetch Result
+          </button>
+        </div>
+      </div>
     </template>
 
     <!-- ── RESPONSE actions (download button) ──────────────── -->
@@ -385,6 +405,8 @@ const scrapeOptions = ref({
 
 /** Whether the "Scrape Options" fieldset is collapsed, matching ScrapeView's pattern. */
 const isScrapeOptionsCollapsed = ref(true);
+
+const resumeId = ref(''); // Job ID typed by the user to resume a previous extract job.
 
 const headersString = ref(''); // Stores the HTTP headers JSON string provided by the user.
 const headersError = ref<string | null>(null); // Stores error messages related to headers JSON parsing.
@@ -651,6 +673,61 @@ const runExtraction = async (): Promise<void> => {
 };
 
 /**
+ * Fetch the result of a previously submitted extract job by its job ID.
+ *
+ * Mirrors `runExtraction`'s state handling so the response pane behaves
+ * identically whether the data came from a fresh run or from a resumed job:
+ * the full response is kept for the invalid-URLs strip and the Sources tab,
+ * and `result` only ever holds the `data` payload.
+ *
+ * A job that is still processing is reported back to the user rather than
+ * treated as a result, since /v2/extract returns no `data` until it finishes.
+ *
+ * @returns A promise that resolves once the status fetch and the state update
+ * are complete.
+ */
+const resumeExtraction = async (): Promise<void> => {
+  const id = resumeId.value.trim();
+  if (!id) {
+    error.value = 'Please enter an extract job ID.';
+    return;
+  }
+
+  try {
+    loading.value = true;
+    error.value = '';
+    result.value = null;
+    fullResponse.value = null;
+    durationMs.value = null;
+
+    const t0 = performance.now();
+    const response = await api.extraction.getExtractStatus(id);
+    durationMs.value = performance.now() - t0;
+    const respData = response.data;
+    // Keep the full response regardless of outcome so invalidURLs and sources
+    // stay visible even when the job itself ended in an error state.
+    fullResponse.value = respData;
+
+    if (respData.status === 'processing') {
+      error.value = 'Job is still processing. Try again in a moment.';
+    } else if (respData.status === 'failed' || respData.status === 'cancelled') {
+      throw new Error(respData.error || `Extract job ${respData.status}`);
+    } else if (respData.data !== undefined && respData.data !== null) {
+      // Either an explicitly completed job, or an older response shape that
+      // carries data without a status field.
+      result.value = respData.data as FirecrawlExtractResponse['data'];
+    } else {
+      throw new Error(respData.error || 'No data returned for this job ID.');
+    }
+  } catch (err: any) {
+    error.value = err?.message || 'Request failed';
+    result.value = null;
+  } finally {
+    loading.value = false;
+  }
+};
+
+/**
  * Download the JSON result to a file.
  */
 const downloadResult = (): void => {
@@ -902,6 +979,65 @@ const downloadResult = (): void => {
 .run-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+
+/* ── Resume by job ID ─────────────────────────────────────────── */
+
+/*
+ * Separated from the form above by a hairline rule: resuming a job is a
+ * distinct entry point, not another field of the extraction request.
+ */
+.resume-group {
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.resume-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* Job IDs are opaque tokens, so the field gets the same mono treatment as
+   the JSON textareas above it. */
+.resume-row input[type='text'] {
+  flex: 1;
+  min-width: 0;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  background: var(--color-background-soft);
+  color: var(--color-text);
+  box-sizing: border-box;
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.resume-row input[type='text']:focus {
+  outline: none;
+  border-color: var(--violet-500);
+  box-shadow: var(--shadow-ring);
+}
+
+.resume-row .action-button {
+  flex-shrink: 0;
+}
+
+.resume-row .action-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Keep the disabled button visually inert instead of lighting up on hover. */
+.resume-row .action-button:disabled:hover {
+  border-color: var(--glass-border);
+  color: var(--color-heading);
+  background: var(--glass-fill);
+  box-shadow: none;
 }
 
 /* ── Response-actions Download button ─────────────────────────── */

--- a/src/views/LlmsTxtView.vue
+++ b/src/views/LlmsTxtView.vue
@@ -1,0 +1,379 @@
+<template>
+  <div class="page-container llms-txt-view">
+    <h2>LLMs.txt Generator</h2>
+    <p class="intro">Generate an LLMs.txt (and optionally full-text) file from any website.</p>
+
+    <form class="llms-form" @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="url">URL:</label>
+        <input id="url" v-model="url" type="url" placeholder="https://example.com" required />
+        <small>The website URL to generate an LLMs.txt file for.</small>
+      </div>
+
+      <div class="form-group">
+        <label for="maxUrls">Max URLs:</label>
+        <input id="maxUrls" v-model.number="maxUrls" type="number" min="1" placeholder="2" />
+        <small>Maximum number of URLs to include in the output.</small>
+      </div>
+
+      <label class="checkbox-label">
+        <input type="checkbox" v-model="showFullText" />
+        Generate full-text version (llms-full.txt)
+      </label>
+
+      <button type="submit" class="primary-button" :disabled="loading">
+        {{ loading ? 'Submitting…' : 'Generate LLMs.txt' }}
+      </button>
+    </form>
+
+    <div v-if="error" class="error">{{ error }}</div>
+
+    <!-- Status while the job is processing -->
+    <div v-if="jobId && generationStatus === 'processing'" class="status-section">
+      <p class="generating-status">Generating… (Job ID: {{ jobId }})</p>
+    </div>
+
+    <!-- Failed state -->
+    <div v-if="generationStatus === 'failed'" class="error">
+      Generation failed. Please try again.
+    </div>
+
+    <!-- Results once the job completes -->
+    <div v-if="generationStatus === 'completed'" class="results">
+      <div class="result-block">
+        <div class="result-header">
+          <h3>llms.txt</h3>
+          <button class="download-button" type="button" @click="downloadLlmsTxt">
+            Download llms.txt
+          </button>
+        </div>
+        <pre class="result-pre">{{ llmstxt }}</pre>
+      </div>
+
+      <div v-if="llmsfulltxt" class="result-block">
+        <div class="result-header">
+          <h3>
+            <button
+              class="collapsible-toggle"
+              type="button"
+              @click="fullTextExpanded = !fullTextExpanded"
+            >
+              {{ fullTextExpanded ? '▾' : '▸' }} llms-full.txt
+            </button>
+          </h3>
+          <button class="download-button" type="button" @click="downloadLlmsFullTxt">
+            Download llms-full.txt
+          </button>
+        </div>
+        <pre v-if="fullTextExpanded" class="result-pre">{{ llmsfulltxt }}</pre>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, inject, onUnmounted } from 'vue';
+import type { FirecrawlLlmsTxtApi, LlmsTxtStatus } from '@/services/firecrawl';
+
+/**
+ * LlmsTxtView Component
+ *
+ * Lets the user submit a URL to generate an LLMs.txt (and optionally a
+ * full-text) file via the Firecrawl API, polls the job status until
+ * completion, and renders the results with download buttons.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * @type {{ llmsTxt?: FirecrawlLlmsTxtApi } | undefined}
+ */
+const api = inject('api') as { llmsTxt?: FirecrawlLlmsTxtApi } | undefined;
+if (!api?.llmsTxt) {
+  throw new Error('LLMs.txt API is not available. Ensure the API plugin is correctly configured.');
+}
+
+/** The website URL to generate the LLMs.txt for. */
+const url = ref('');
+/** Maximum number of URLs to include in the output. */
+const maxUrls = ref<number>(2);
+/** Whether to also generate the full-text version. */
+const showFullText = ref(false);
+
+/** Whether a submission request is currently in flight. */
+const loading = ref(false);
+/** User-facing error message. */
+const error = ref('');
+
+/** Identifier of the running generation job, or null when idle. */
+const jobId = ref<string | null>(null);
+/** Current job status, or null when no job has been started. */
+const generationStatus = ref<LlmsTxtStatus['status'] | null>(null);
+/** Generated llms.txt content. */
+const llmstxt = ref('');
+/** Generated llms-full.txt content, empty when not requested or unavailable. */
+const llmsfulltxt = ref('');
+/** Whether the collapsible full-text block is expanded. */
+const fullTextExpanded = ref(false);
+
+/** Polling interval handle. */
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Stop the status polling loop, if any is active.
+ */
+function stopPolling(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Poll the LLMs.txt status endpoint until the job completes or fails.
+ *
+ * @param id - The generation job identifier.
+ */
+function pollStatus(id: string): void {
+  stopPolling();
+  intervalId = setInterval(async () => {
+    try {
+      const response = await api.llmsTxt!.getLlmsTxtStatus(id);
+      const data = response.data;
+      generationStatus.value = data.status;
+
+      if (data.status === 'completed') {
+        llmstxt.value = data.llmstxt;
+        llmsfulltxt.value = data.llmsfulltxt;
+        stopPolling();
+      } else if (data.status === 'failed') {
+        stopPolling();
+      }
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch generation status.';
+      generationStatus.value = 'failed';
+      stopPolling();
+    }
+  }, 3000);
+}
+
+/**
+ * Submit the LLMs.txt generation job from the current form inputs and start polling.
+ *
+ * @returns {Promise<void>} Resolves once the job has been submitted.
+ */
+async function handleSubmit(): Promise<void> {
+  if (!url.value) {
+    error.value = 'Please enter a URL.';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  jobId.value = null;
+  generationStatus.value = null;
+  llmstxt.value = '';
+  llmsfulltxt.value = '';
+  fullTextExpanded.value = false;
+
+  try {
+    const response = await api.llmsTxt!.generateLlmsTxt({
+      url: url.value,
+      maxUrls: maxUrls.value,
+      showFullText: showFullText.value,
+    });
+    jobId.value = response.data.id;
+    generationStatus.value = 'processing';
+    pollStatus(response.data.id);
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to start LLMs.txt generation.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+/**
+ * Trigger a browser download of the generated llms.txt content.
+ */
+function downloadLlmsTxt(): void {
+  const blob = new Blob([llmstxt.value], { type: 'text/plain' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'llms.txt';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+/**
+ * Trigger a browser download of the generated llms-full.txt content.
+ */
+function downloadLlmsFullTxt(): void {
+  const blob = new Blob([llmsfulltxt.value], { type: 'text/plain' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'llms-full.txt';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+// Clean up the polling loop when the component is destroyed.
+onUnmounted(stopPolling);
+</script>
+
+<style scoped>
+.llms-txt-view {
+  max-width: 700px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.llms-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+input[type='url'],
+input[type='number'] {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
+}
+
+.form-group small {
+  font-size: 0.8em;
+  color: var(--color-text);
+  opacity: 0.7;
+  margin-top: 3px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: normal;
+}
+
+.primary-button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-section {
+  margin-top: 1.5rem;
+}
+
+.generating-status {
+  font-style: italic;
+  color: var(--color-text);
+  opacity: 0.7;
+}
+
+.results {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.result-block {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-background-soft);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.result-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.result-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 1rem;
+  margin: 0;
+  font-size: 0.85rem;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
+  font-family: monospace;
+}
+
+.collapsible-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: bold;
+  padding: 0;
+  color: inherit;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/views/LlmsTxtView.vue
+++ b/src/views/LlmsTxtView.vue
@@ -36,6 +36,10 @@
         Served by the <code>/{{ apiVersion }}</code> endpoint. This Firecrawl install does not
         expose <code>/v2</code> for this feature.
       </p>
+      <!-- Deprecation notices the API itself returned, shown verbatim -->
+      <ul v-if="apiWarnings.length" class="api-version-notice">
+        <li v-for="(warning, index) in apiWarnings" :key="index">{{ warning }}</li>
+      </ul>
     </div>
 
     <!-- Failed state -->
@@ -121,6 +125,8 @@ const llmsfulltxt = ref('');
 const fullTextExpanded = ref(false);
 /** API version the connected Firecrawl instance actually served this job on. */
 const apiVersion = ref<FirecrawlApiVersion | null>(null);
+/** Deprecation notices returned by the API for this job. */
+const apiWarnings = ref<string[]>([]);
 
 /** Polling interval handle. */
 let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -148,6 +154,7 @@ function pollStatus(id: string): void {
       const data = response.data;
       generationStatus.value = data.status;
       apiVersion.value = data.apiVersion;
+      apiWarnings.value = data.warnings;
 
       if (data.status === 'completed') {
         llmstxt.value = data.llmstxt;

--- a/src/views/LlmsTxtView.vue
+++ b/src/views/LlmsTxtView.vue
@@ -31,6 +31,11 @@
     <!-- Status while the job is processing -->
     <div v-if="jobId && generationStatus === 'processing'" class="status-section">
       <p class="generating-status">Generating… (Job ID: {{ jobId }})</p>
+      <!-- Explicit downgrade notice: self-hosted installs only serve the v1 endpoint -->
+      <p v-if="apiVersion && apiVersion !== 'v2'" class="api-version-notice">
+        Served by the <code>/{{ apiVersion }}</code> endpoint. This Firecrawl install does not
+        expose <code>/v2</code> for this feature.
+      </p>
     </div>
 
     <!-- Failed state -->
@@ -73,7 +78,7 @@
 
 <script setup lang="ts">
 import { ref, inject, onUnmounted } from 'vue';
-import type { FirecrawlLlmsTxtApi, LlmsTxtStatus } from '@/services/firecrawl';
+import type { FirecrawlApiVersion, FirecrawlLlmsTxtApi, LlmsTxtStatus } from '@/services/firecrawl';
 
 /**
  * LlmsTxtView Component
@@ -114,6 +119,8 @@ const llmstxt = ref('');
 const llmsfulltxt = ref('');
 /** Whether the collapsible full-text block is expanded. */
 const fullTextExpanded = ref(false);
+/** API version the connected Firecrawl instance actually served this job on. */
+const apiVersion = ref<FirecrawlApiVersion | null>(null);
 
 /** Polling interval handle. */
 let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -140,6 +147,7 @@ function pollStatus(id: string): void {
       const response = await api.llmsTxt!.getLlmsTxtStatus(id);
       const data = response.data;
       generationStatus.value = data.status;
+      apiVersion.value = data.apiVersion;
 
       if (data.status === 'completed') {
         llmstxt.value = data.llmstxt;
@@ -182,6 +190,7 @@ async function handleSubmit(): Promise<void> {
       showFullText: showFullText.value,
     });
     jobId.value = response.data.id;
+    apiVersion.value = response.data.apiVersion;
     generationStatus.value = 'processing';
     pollStatus(response.data.id);
   } catch (err: unknown) {
@@ -375,5 +384,16 @@ input[type='number'] {
 .error {
   color: #d9534f;
   margin-top: 0.75rem;
+}
+
+.api-version-notice {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-soft, #6b7280);
+}
+
+.api-version-notice code {
+  font-family: inherit;
+  font-weight: 600;
 }
 </style>

--- a/src/views/ResearchView.vue
+++ b/src/views/ResearchView.vue
@@ -1,0 +1,718 @@
+<template>
+  <div class="page-container research-view">
+    <h2>Deep Research</h2>
+    <p class="intro">
+      Run an AI-powered deep research job that crawls the web and synthesises a final analysis.
+    </p>
+
+    <form class="research-form" @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="query">Research Query:</label>
+        <textarea
+          id="query"
+          v-model="query"
+          rows="4"
+          placeholder="What is the current state of quantum computing?"
+          required
+        ></textarea>
+        <small>Describe the topic or question you want researched.</small>
+      </div>
+
+      <!-- Advanced options collapsible block -->
+      <div class="advanced-toggle">
+        <button type="button" class="toggle-button" @click="showAdvanced = !showAdvanced">
+          {{ showAdvanced ? 'Hide' : 'Show' }} Advanced Options
+        </button>
+      </div>
+
+      <div v-if="showAdvanced" class="advanced-options">
+        <div class="form-row">
+          <div class="form-group">
+            <label for="maxDepth">Max Depth (1–12):</label>
+            <input id="maxDepth" v-model.number="maxDepth" type="number" min="1" max="12" />
+            <small>How many research hops to perform.</small>
+          </div>
+
+          <div class="form-group">
+            <label for="timeLimit">Time Limit (seconds, 30–600):</label>
+            <input id="timeLimit" v-model.number="timeLimit" type="number" min="30" max="600" />
+            <small>Maximum wall-clock time for the job.</small>
+          </div>
+
+          <div class="form-group">
+            <label for="maxUrls">Max URLs (1–1000):</label>
+            <input id="maxUrls" v-model.number="maxUrls" type="number" min="1" max="1000" />
+            <small>Cap on total URLs visited.</small>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="analysisPrompt">Analysis Prompt (optional):</label>
+          <textarea
+            id="analysisPrompt"
+            v-model="analysisPrompt"
+            rows="3"
+            placeholder="Focus the final analysis on practical applications."
+          ></textarea>
+          <small>Guide the synthesis step with a custom prompt.</small>
+        </div>
+
+        <div class="form-group">
+          <label for="systemPrompt">System Prompt (optional):</label>
+          <textarea
+            id="systemPrompt"
+            v-model="systemPrompt"
+            rows="3"
+            placeholder="You are an expert researcher. Be concise and cite sources."
+          ></textarea>
+          <small>Override the default system prompt used during research.</small>
+        </div>
+
+        <div class="form-group">
+          <label for="formats">Output Formats:</label>
+          <select id="formats" v-model="selectedFormats" multiple>
+            <option value="markdown">Markdown</option>
+            <option value="json">JSON</option>
+          </select>
+          <small>Select one or more output formats.</small>
+        </div>
+      </div>
+
+      <button type="submit" class="primary-button" :disabled="loading">
+        {{ loading ? 'Starting…' : 'Start Deep Research' }}
+      </button>
+    </form>
+
+    <div v-if="error" class="error">{{ error }}</div>
+
+    <!-- Progress while the research job is processing -->
+    <div v-if="jobId && jobStatus === 'processing'" class="status-section">
+      <h3>Research in Progress</h3>
+      <p>Job ID: {{ jobId }}</p>
+      <p class="progress-line">
+        Depth {{ currentDepth }}/{{ maxDepthReported }} &middot; {{ totalUrls }} URLs visited
+      </p>
+
+      <div v-if="activities.length" class="activities">
+        <h4>Live Activity</h4>
+        <ul class="activity-list">
+          <li v-for="(activity, index) in activitiesNewestFirst" :key="index" class="activity-item">
+            <span class="activity-status" :class="activityClass(activity.status)">
+              {{ activity.status ?? 'info' }}
+            </span>
+            <span class="activity-message">{{ activity.message }}</span>
+            <span v-if="activity.timestamp" class="activity-timestamp">
+              {{ formatTimestamp(activity.timestamp) }}
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Failed state -->
+    <div v-if="jobStatus === 'failed'" class="status-section">
+      <h3>Research Failed</h3>
+      <div class="error">
+        {{ researchError ?? 'The research job encountered an unexpected error.' }}
+      </div>
+    </div>
+
+    <!-- Completed state: sources + final analysis -->
+    <div v-if="jobStatus === 'completed'" class="results">
+      <h3>Research Complete</h3>
+
+      <div v-if="sources.length" class="sources-section">
+        <h4>Sources ({{ sources.length }})</h4>
+        <ul class="source-list">
+          <li v-for="(source, index) in sources" :key="index" class="source-item">
+            <img
+              v-if="source.favicon"
+              :src="source.favicon"
+              alt=""
+              class="source-favicon"
+              aria-hidden="true"
+            />
+            <div class="source-body">
+              <a
+                v-if="source.url"
+                :href="source.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="source-title"
+              >
+                {{ source.title ?? source.url }}
+              </a>
+              <span v-else class="source-title">{{ source.title ?? 'Unknown source' }}</span>
+              <p v-if="source.description" class="source-description">{{ source.description }}</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div v-if="finalAnalysis" class="analysis-section">
+        <h4>Final Analysis</h4>
+        <pre class="analysis-content">{{ finalAnalysis }}</pre>
+      </div>
+
+      <div class="download-buttons">
+        <button
+          v-if="finalAnalysis"
+          type="button"
+          class="download-button"
+          @click="downloadMarkdown"
+        >
+          Download Markdown
+        </button>
+        <button
+          v-if="researchJson !== null"
+          type="button"
+          class="download-button"
+          @click="downloadJson"
+        >
+          Download JSON
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, inject, onUnmounted } from 'vue';
+import type {
+  FirecrawlResearchApi,
+  DeepResearchStatus,
+  ResearchActivity,
+  ResearchSource,
+} from '@/services/firecrawl';
+
+/**
+ * ResearchView Component
+ *
+ * Lets the user submit a deep research query, polls the job status until
+ * completion, and renders the final analysis and discovered sources with
+ * download options.
+ */
+
+/**
+ * Injects the API instance provided by the API plugin.
+ * @type {{ research?: FirecrawlResearchApi } | undefined}
+ */
+const api = inject('api') as { research?: FirecrawlResearchApi } | undefined;
+if (!api?.research) {
+  throw new Error('Research API is not available. Ensure the API plugin is correctly configured.');
+}
+
+// --- Form state ---
+
+/** The main research question entered by the user. */
+const query = ref('');
+/** Whether the advanced options block is expanded. */
+const showAdvanced = ref(false);
+/** Maximum research depth (1–12). */
+const maxDepth = ref(7);
+/** Time limit in seconds (30–600). */
+const timeLimit = ref(300);
+/** Maximum number of URLs to visit (1–1000). */
+const maxUrls = ref(20);
+/** Optional custom analysis prompt. */
+const analysisPrompt = ref('');
+/** Optional custom system prompt. */
+const systemPrompt = ref('');
+/** Selected output formats. */
+const selectedFormats = ref<string[]>(['markdown']);
+
+// --- Async / job state ---
+
+/** Whether a submission request is currently in flight. */
+const loading = ref(false);
+/** User-facing error message for submission failures. */
+const error = ref('');
+
+/** Identifier of the running research job, or null when idle. */
+const jobId = ref<string | null>(null);
+/** Current job lifecycle status. */
+const jobStatus = ref<DeepResearchStatus['status'] | null>(null);
+/** Current crawl depth reported by the server. */
+const currentDepth = ref(0);
+/** Max depth as reported by the server status response. */
+const maxDepthReported = ref(0);
+/** Total URLs visited so far. */
+const totalUrls = ref(0);
+/** Live activity log from the server. */
+const activities = ref<ResearchActivity[]>([]);
+/** Discovered sources once the job completes. */
+const sources = ref<ResearchSource[]>([]);
+/** Final analysis text once the job completes. */
+const finalAnalysis = ref('');
+/** JSON result from the server, if any. */
+const researchJson = ref<Record<string, unknown> | null>(null);
+/** Error message reported by the server on failure. */
+const researchError = ref<string | null>(null);
+
+/** Polling interval handle. */
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+// --- Computed ---
+
+/**
+ * Returns the activities list sorted newest-first for display.
+ */
+const activitiesNewestFirst = computed<ResearchActivity[]>(() => [...activities.value].reverse());
+
+// --- Helpers ---
+
+/**
+ * Stop the status polling loop, if any is active.
+ */
+function stopPolling(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Apply a server status response snapshot to the reactive state.
+ *
+ * @param data - The deep research status object returned by the API.
+ */
+function applyStatus(data: DeepResearchStatus): void {
+  jobStatus.value = data.status;
+  currentDepth.value = data.currentDepth;
+  maxDepthReported.value = data.maxDepth;
+  totalUrls.value = data.totalUrls;
+  activities.value = data.activities;
+
+  if (data.status === 'completed') {
+    sources.value = data.sources;
+    finalAnalysis.value = data.finalAnalysis;
+    researchJson.value = data.json;
+  }
+
+  if (data.status === 'failed') {
+    researchError.value = data.error;
+  }
+}
+
+/**
+ * Poll the deep research status endpoint until the job completes or fails.
+ *
+ * @param id - The research job identifier.
+ */
+function pollStatus(id: string): void {
+  stopPolling();
+  intervalId = setInterval(async () => {
+    try {
+      const response = await api.research!.getDeepResearchStatus(id);
+      applyStatus(response.data);
+
+      if (response.data.status === 'completed' || response.data.status === 'failed') {
+        stopPolling();
+      }
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch research status.';
+      jobStatus.value = 'failed';
+      stopPolling();
+    }
+  }, 3000);
+}
+
+/**
+ * Build a CSS class name based on the activity status string for colour coding.
+ *
+ * @param status - The activity status value (may be undefined).
+ * @returns A CSS class string.
+ */
+function activityClass(status: string | undefined): string {
+  switch (status) {
+    case 'completed':
+      return 'status-completed';
+    case 'failed':
+      return 'status-failed';
+    case 'processing':
+      return 'status-processing';
+    default:
+      return 'status-info';
+  }
+}
+
+/**
+ * Format an ISO 8601 timestamp into a compact, locale-aware time string.
+ *
+ * @param timestamp - An ISO 8601 timestamp string.
+ * @returns A short time string suitable for the activity list.
+ */
+function formatTimestamp(timestamp: string): string {
+  try {
+    return new Date(timestamp).toLocaleTimeString();
+  } catch {
+    return timestamp;
+  }
+}
+
+/**
+ * Trigger a browser file download for the given content.
+ *
+ * @param content - The file content as a string.
+ * @param filename - The suggested download filename.
+ * @param mimeType - The MIME type of the file.
+ */
+function triggerDownload(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
+
+/**
+ * Download the final analysis as a Markdown file.
+ */
+function downloadMarkdown(): void {
+  triggerDownload(
+    finalAnalysis.value,
+    `deep-research-${jobId.value ?? 'result'}.md`,
+    'text/markdown',
+  );
+}
+
+/**
+ * Download the JSON result as a JSON file.
+ */
+function downloadJson(): void {
+  if (researchJson.value === null) {
+    return;
+  }
+  triggerDownload(
+    JSON.stringify(researchJson.value, null, 2),
+    `deep-research-${jobId.value ?? 'result'}.json`,
+    'application/json',
+  );
+}
+
+/**
+ * Submit the deep research job from the current form inputs and start polling.
+ *
+ * @returns {Promise<void>} Resolves once the job has been submitted.
+ */
+async function handleSubmit(): Promise<void> {
+  if (!query.value.trim()) {
+    error.value = 'Please enter a research query.';
+    return;
+  }
+  if (selectedFormats.value.length === 0) {
+    error.value = 'Please select at least one output format.';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  jobId.value = null;
+  jobStatus.value = null;
+  activities.value = [];
+  sources.value = [];
+  finalAnalysis.value = '';
+  researchJson.value = null;
+  researchError.value = null;
+
+  const payload: Record<string, unknown> = {
+    query: query.value.trim(),
+    maxDepth: maxDepth.value,
+    timeLimit: timeLimit.value,
+    maxUrls: maxUrls.value,
+    formats: selectedFormats.value,
+    ...(analysisPrompt.value.trim() ? { analysisPrompt: analysisPrompt.value.trim() } : {}),
+    ...(systemPrompt.value.trim() ? { systemPrompt: systemPrompt.value.trim() } : {}),
+  };
+
+  try {
+    const response = await api.research!.startDeepResearch(payload);
+    jobId.value = response.data.id;
+    jobStatus.value = 'processing';
+    pollStatus(response.data.id);
+  } catch (err: unknown) {
+    error.value = err instanceof Error ? err.message : 'Failed to start deep research.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Clean up the polling loop when the component is destroyed.
+onUnmounted(stopPolling);
+</script>
+
+<style scoped>
+.research-view {
+  max-width: 700px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}
+
+.intro {
+  margin-bottom: 1rem;
+  opacity: 0.8;
+}
+
+.research-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.form-row .form-group {
+  flex: 1;
+  min-width: 140px;
+}
+
+label {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+textarea,
+select,
+input[type='number'] {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-background-mute);
+  color: var(--color-text);
+}
+
+.form-group small {
+  font-size: 0.8em;
+  color: var(--color-text);
+  opacity: 0.7;
+  margin-top: 3px;
+}
+
+.advanced-toggle {
+  margin-top: -0.25rem;
+}
+
+.toggle-button {
+  background: none;
+  border: none;
+  color: #007acc;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.toggle-button:hover {
+  color: #005fa3;
+}
+
+.advanced-options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background-color: var(--color-background-soft);
+}
+
+.primary-button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover:not(:disabled) {
+  background-color: #005fa3;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-section {
+  margin-top: 1.5rem;
+}
+
+.progress-line {
+  font-weight: bold;
+  color: #007acc;
+}
+
+.activities {
+  margin-top: 1rem;
+}
+
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.activity-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  background-color: var(--color-background-soft);
+}
+
+.activity-status {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.7em;
+  white-space: nowrap;
+}
+
+.status-completed {
+  color: #4caf50;
+}
+
+.status-failed {
+  color: #d9534f;
+}
+
+.status-processing {
+  color: #007acc;
+}
+
+.status-info {
+  color: var(--color-text);
+  opacity: 0.7;
+}
+
+.activity-message {
+  flex: 1;
+}
+
+.activity-timestamp {
+  font-size: 0.75em;
+  color: var(--color-text);
+  opacity: 0.6;
+  white-space: nowrap;
+}
+
+.results {
+  margin-top: 1.5rem;
+}
+
+.sources-section {
+  margin-bottom: 1.5rem;
+}
+
+.source-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.source-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.source-favicon {
+  width: 16px;
+  height: 16px;
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+
+.source-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.source-title {
+  font-weight: bold;
+  color: #007acc;
+  word-break: break-word;
+}
+
+a.source-title:hover {
+  text-decoration: underline;
+}
+
+.source-description {
+  font-size: 0.85rem;
+  color: var(--color-text);
+  opacity: 0.7;
+  margin: 0;
+}
+
+.analysis-section {
+  margin-bottom: 1rem;
+}
+
+.analysis-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background-color: var(--color-background-mute);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 1rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.download-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.download-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: #d9534f;
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/views/ResearchView.vue
+++ b/src/views/ResearchView.vue
@@ -92,6 +92,11 @@
       <p class="progress-line">
         Depth {{ currentDepth }}/{{ maxDepthReported }} &middot; {{ totalUrls }} URLs visited
       </p>
+      <!-- Explicit downgrade notice: self-hosted installs only serve the v1 endpoint -->
+      <p v-if="apiVersion && apiVersion !== 'v2'" class="api-version-notice">
+        Served by the <code>/{{ apiVersion }}</code> endpoint. This Firecrawl install does not
+        expose <code>/v2</code> for this feature.
+      </p>
 
       <div v-if="activities.length" class="activities">
         <h4>Live Activity</h4>
@@ -179,6 +184,7 @@
 <script setup lang="ts">
 import { ref, computed, inject, onUnmounted } from 'vue';
 import type {
+  FirecrawlApiVersion,
   FirecrawlResearchApi,
   DeepResearchStatus,
   ResearchActivity,
@@ -248,6 +254,8 @@ const finalAnalysis = ref('');
 const researchJson = ref<Record<string, unknown> | null>(null);
 /** Error message reported by the server on failure. */
 const researchError = ref<string | null>(null);
+/** API version the connected Firecrawl instance actually served this job on. */
+const apiVersion = ref<FirecrawlApiVersion | null>(null);
 
 /** Polling interval handle. */
 let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -278,6 +286,7 @@ function stopPolling(): void {
  */
 function applyStatus(data: DeepResearchStatus): void {
   jobStatus.value = data.status;
+  apiVersion.value = data.apiVersion;
   currentDepth.value = data.currentDepth;
   maxDepthReported.value = data.maxDepth;
   totalUrls.value = data.totalUrls;
@@ -431,6 +440,7 @@ async function handleSubmit(): Promise<void> {
   try {
     const response = await api.research!.startDeepResearch(payload);
     jobId.value = response.data.id;
+    apiVersion.value = response.data.apiVersion;
     jobStatus.value = 'processing';
     pollStatus(response.data.id);
   } catch (err: unknown) {
@@ -714,5 +724,16 @@ a.source-title:hover {
 .error {
   color: #d9534f;
   margin-top: 0.75rem;
+}
+
+.api-version-notice {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-soft, #6b7280);
+}
+
+.api-version-notice code {
+  font-family: inherit;
+  font-weight: 600;
 }
 </style>

--- a/src/views/ResearchView.vue
+++ b/src/views/ResearchView.vue
@@ -97,6 +97,10 @@
         Served by the <code>/{{ apiVersion }}</code> endpoint. This Firecrawl install does not
         expose <code>/v2</code> for this feature.
       </p>
+      <!-- Deprecation notices the API itself returned, shown verbatim -->
+      <ul v-if="apiWarnings.length" class="api-version-notice">
+        <li v-for="(warning, index) in apiWarnings" :key="index">{{ warning }}</li>
+      </ul>
 
       <div v-if="activities.length" class="activities">
         <h4>Live Activity</h4>
@@ -256,6 +260,8 @@ const researchJson = ref<Record<string, unknown> | null>(null);
 const researchError = ref<string | null>(null);
 /** API version the connected Firecrawl instance actually served this job on. */
 const apiVersion = ref<FirecrawlApiVersion | null>(null);
+/** Deprecation notices returned by the API for this job. */
+const apiWarnings = ref<string[]>([]);
 
 /** Polling interval handle. */
 let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -287,6 +293,7 @@ function stopPolling(): void {
 function applyStatus(data: DeepResearchStatus): void {
   jobStatus.value = data.status;
   apiVersion.value = data.apiVersion;
+  apiWarnings.value = data.warnings;
   currentDepth.value = data.currentDepth;
   maxDepthReported.value = data.maxDepth;
   totalUrls.value = data.totalUrls;


### PR DESCRIPTION
Reopens the work from #85, rebuilt on current main.

## TL;DR

Adds the Firecrawl endpoints the UI did not cover yet: team billing, batch scrape, active crawls, crawl error reports, extract resume, deep research and LLMs.txt generation. Deep research and LLMs.txt only exist under `/v1` on self-hosted installs, so the adapter probes `/v2` and falls back to `/v1` on a 404.

## Why this is a new branch

#85 was closed with a request to verify the endpoints against the official docs. I checked them against a self-hosted instance instead, which answered the question directly:

| Endpoint | Result |
| --- | --- |
| `POST /v2/batch/scrape` | exists |
| `GET /v2/crawl/active` | exists |
| `GET /v2/team/credit-usage` | exists |
| `GET /v2/team/token-usage` | exists |
| `POST /v2/deep-research` | 404, only `/v1/deep-research` answers |
| `POST /v2/llmstxt` | 404, only `/v1/llmstxt` answers |

The old branch could not be rebased. main has rewritten `HomeView`, `CrawlView` and `ExtractView` since it forked (727, 1278 and 996 lines of drift), so it was patching a UI that no longer exists. The adapter and the router still applied cleanly, so those were merged three-way and the three view integrations were reimplemented against the current design.

## The fallback

`requestWithVersionFallback()` in `src/services/firecrawl.ts` tries `/v2` first and retries on `/v1` when the response is a 404. Any other error propagates untouched.

The resolved version is cached per feature for the lifetime of the client, because a job started on `/v1` has to be polled on `/v1`: the same job id returns 404 on the other version.

The downgrade shows up in the interface. It is logged once, and the research and LLMs.txt views display which endpoint served the job, along with the deprecation notices the API itself returns:

```
/v1/llmstxt is deprecated and will not be replaced.
/v1/deep-research is deprecated. Use /v2/search instead.
```

Worth knowing before building further on those two: LLMs.txt has no replacement planned, and deep research is being folded into `/v2/search`.

The v1 status payload is also shaped differently. `/v1/deep-research/{id}` returns `status`, `currentDepth`, `maxDepth` and `totalUrls` at the top level and nests only `activities` and `sources`, while `/v2` nests everything under `data`. Reading `data` alone left every fallback job stuck on "processing" at depth 0, so the adapter now merges both levels, nested first.

## What this adds to the UI

Batch Scrape, Research and LLMs.txt are header tabs, Billing is an icon next to the API configuration. The home launcher is unchanged: it pushes `/${action}?url=<url>` and none of the four new views read `route.query.url`.

`CrawlView` gets the per-URL error report and the robots-blocked list in the Status tab, plus an active crawls list at the top of History. `ExtractView` gets resume by job id. Both were written against the current theme tokens, so dark mode stays legible.

## Testing

`npx eslint .`, `npx prettier --check .` and `npm run build` all pass. `vue-tsc --noEmit` is clean apart from a pre-existing TS2688 about a missing `@types/node`.

The v1 fallback path was exercised against a live self-hosted instance: both jobs start, the status polls return the shape the adapter parses, and the same job ids return 404 under `/v2`.

This project has no automated tests.
